### PR TITLE
Hebr.5,1-2;11;13

### DIFF
--- a/1879/58-heb/05.txt
+++ b/1879/58-heb/05.txt
@@ -1,5 +1,5 @@
-Albowiem każdy najwyższy kapłan z ludzi wzięty, za ludzi bywa postanowiony w tych rzeczach, które do Boga należą, to jest, aby ofiarował dary i ofiary za grzechy.
-Który by mógł, jako przystoi, użalić się nieumiejętnych i błądzących, będący sam obłożony krewkością.
+Albowiem każdy najwyższy kapłan z ludzi wzięty za ludzi bywa postanowiony w tych rzeczach, które do Boga należą, to jest, aby ofiarował dary, i ofiary za grzechy.
+Któryby mógł, jako przystoi, użalić się nieumiejętnych i błądzących, będący sam obłożony krewkością.
 A dla tej jest powinien, jako za lud, tak i sam za się ofiarować za grzechy.
 A nikt sobie tej czci nie bierze, tylko ten, który bywa powołany od Boga jako i Aaron.
 Tak i Chrystus nie sam sobie tej czci przywłaszczył, aby się stał najwyższym kapłanem; ale ten, który mu rzekł: Syn mój jesteś ty, jam cię dziś spłodził.
@@ -8,7 +8,7 @@ Który za dni ciała swego modlitwy i uniżone prośby do tego, który go mógł
 A choć był Synem Bożym, wszakże z tego, co cierpiał, nauczył się posłuszeństwa.
 A tak doskonałym będąc, stał się wszystkim sobie posłusznym przyczyną zbawienia wiecznego,
 Nazwany będąc od Boga kapłanem najwyższym według porządku Melchisedekowego.
-O którym wiele by się miało mówić i trudnych rzeczy do wyłożenia; aleście się wy stali leniwi ku słuchaniu.
+O którym wieleby się miało mówić, i trudnych rzeczy do wyłożenia; aleście się wy stali leniwi ku słuchaniu.
 Albowiem mając być nauczycielami względem czasu, zasię potrzebujecie, aby was uczono, które są pierwsze początki mów Bożych, i staliście się jako mleka potrzebujący, a nie twardego pokarmu.
-Bo każdy, co się tylko mlekiem karmi, ten nie jest powiadomy mowy sprawiedliwości: (gdyż jest niemowlątkiem),
+Bo każdy, co się tylko mlekiem karmi, ten nie jest powiadomy mowy sprawiedliwości; (gdyż jest niemowlątkiem,)
 Aleć doskonałym należy twardy pokarm, to jest tym, którzy przez przyzwyczajenie mają zmysły wyćwiczone ku rozeznaniu dobrego i złego.


### PR DESCRIPTION
w.1. przecinek za "wzięty," jest w 1632
w.13 średnik za "sprawiedliwości;" jest dwukropkiem w 1632