### PR TITLE
Dzie.10,2;6-7;9-10;12-13;17;20;22-23;25;29-30;35;40-42.

### DIFF
--- a/1879/44-act/10.txt
+++ b/1879/44-act/10.txt
@@ -4,7 +4,7 @@ A ten się zawsze Bogu modląc, widział jawnie w widzeniu, jakoby o dziewiątej
 A on pilnie nań patrząc, a przestraszony będąc, rzekł: Cóż jest, Panie? I rzekł mu: Modlitwy twoje i jałmużny twoje wstąpiły na pamięć przed obliczność Bożą.
 Przetoż teraz poślij męże do Joppy, a przyzwij Szymona, którego zowią Piotrem.
 Ten ma gospodę u niektórego Szymona, garbarza, który ma dom nad morzem; tenci powie, cobyś miał czynić.
-A gdy odszedł Anioł, który mówił z Kornelijuszem, zawoławszy dwóch sług swoich, i żołnierza pobożnego z tych którzy przy nim ustawicznie byli;
+A gdy odszedł Anioł, który mówił z Kornelijuszem, zawoławszy dwóch sług swoich, i żołnierza pobożnego z tych, którzy przy nim ustawicznie byli;
 A rozpowiedziawszy im wszystko, posłał je do Joppy.
 A nazajutrz, gdy byli w drodze, a przybliżali się do miasta, wstąpił Piotr na dach, aby się modlił, około godziny szóstej.
 A będąc łaknącym chciał jeść; a gdy mu oni jeść gotowali, przypadło nań zachwycenie.

--- a/1879/44-act/10.txt
+++ b/1879/44-act/10.txt
@@ -1,45 +1,45 @@
 A w Cezaryi był mąż niektóry, imieniem Kornelijusz, setnik, z roty, którą zwano Włoską;
-Pobożny i bojący się Boga ze wszystkim domem swoim, i czyniący jałmużny wielkie ludowi.
+Pobożny, i bojący się Boga ze wszystkim domem swoim, i czyniący jałmużny wielkie ludowi.
 A ten się zawsze Bogu modląc, widział jawnie w widzeniu, jakoby o dziewiątej godzinie na dzień, Anioła Bożego, że wszedł do niego i rzekł mu: Kornelijuszu!
 A on pilnie nań patrząc, a przestraszony będąc, rzekł: Cóż jest, Panie? I rzekł mu: Modlitwy twoje i jałmużny twoje wstąpiły na pamięć przed obliczność Bożą.
 Przetoż teraz poślij męże do Joppy, a przyzwij Szymona, którego zowią Piotrem.
-Ten ma gospodę u niektórego Szymona, garbarza, który ma dom nad morzem; ten ci powie, co byś miał czynić.
-A gdy odszedł Anioł, który mówił z Kornelijuszem, zawoławszy dwóch sług swoich i żołnierza pobożnego z tych, którzy przy nim ustawicznie byli;
+Ten ma gospodę u niektórego Szymona, garbarza, który ma dom nad morzem; tenci powie, cobyś miał czynić.
+A gdy odszedł Anioł, który mówił z Kornelijuszem, zawoławszy dwóch sług swoich, i żołnierza pobożnego z tych którzy przy nim ustawicznie byli;
 A rozpowiedziawszy im wszystko, posłał je do Joppy.
-A nazajutrz, gdy byli w drodze, a przybliżali się do miasta, wstąpił Piotr na dach, aby się modlił około godziny szóstej.
-A będąc łaknącym chciał jeść; a gdy mu oni jeść gotowali, przypadło na niego zachwycenie.
+A nazajutrz, gdy byli w drodze, a przybliżali się do miasta, wstąpił Piotr na dach, aby się modlił, około godziny szóstej.
+A będąc łaknącym chciał jeść; a gdy mu oni jeść gotowali, przypadło nań zachwycenie.
 I ujrzał niebo otworzone i zstępujące na się naczynie niejakie, jakoby prześcieradło wielkie, za cztery rogi uwiązane i spuszczone na ziemię;
-W którem były wszelkie ziemskie czworonogie zwierzęta i bestyje, i gadziny i ptastwo niebieskie.
-I stał się głos do niego: Wstań Piotrze! rzeż, a jedz.
+W którem były wszelkie ziemskie czworonogie zwierzęta, i bestyje, i gadziny i ptastwo niebieskie.
+I stał się głos do niego: Wstań Piotrze! rzeż a jedz.
 A Piotr rzekł: Żadną miarą, Panie! gdyżem nigdy nie jadł nic pospolitego albo nieczystego.
 Tedy zasię powtóre stał się głos do niego: Co Bóg oczyścił, ty nie miej tego za nieczyste.
 A to się stało po trzykroć. I wzięte jest zasię ono naczynie do nieba.
-A gdy Piotr sam w sobie wątpił, co by to było za widzenie, które widział, tedy oto ci mężowie, którzy byli posłani do Kornelijusza, pytający się o dom Szymonowy, stali przede drzwiami;
+A gdy Piotr sam w sobie wątpił coby to było za widzenie które widział: tedy oto ci mężowie, którzy byli posłani od Kornelijusza, pytający się o dom Szymonowy, stali przede drzwiami;
 A zawoławszy, wywiadywali się, jeźliby tam Szymon, którego zowią Piotrem, gospodę miał.
 A gdy Piotr myślił o onem widzeniu, rzekł mu Duch: Oto cię trzej mężowie szukają.
-Przetoż wstawszy, zstąp, a idź z nimi, nic nie wątpiąc, bomci ja je posłał.
+Przetoż wstawszy, zstąp, a idź z nimi, nic nie wątpiąc: bomci ja je posłał.
 Tedy Piotr zstąpiwszy do onych mężów, którzy od Kornelijusza do niego posłani byli, rzekł: Otom ja jest, którego szukacie. Cóż za przyczyna, dla którejście przyszli?
-A oni rzekli: Kornelijusz setnik, mąż sprawiedliwy i bojący się Boga i mający dobre świadectwo od wszystkiego narodu żydowskiego, w widzeniu jest od Anioła świętego napomniony, aby cię wezwał w dom swój i słuchał słów od ciebie.
-Tedy zawoławszy ich do domu, przyjął je do gospody. A drugiego dnia Piotr szedł z nimi i niektórzy z braci z Joppy szli z nimi.
+A oni rzekli: Kornelijusz setnik, mąż sprawiedliwy i bojący się Boga i mający dobre świadectwo od wszystkiego narodu żydowskiego, w widzeniu jest od Anioła świętego napomniony, aby cię wezwał w dom swój, i słuchał słów od ciebie.
+Tedy zawoławszy ich do domu, przyjął je do gospody. A drugiego dnia Piotr szedł z nimi, i niektórzy z braci z Joppy szli z nim.
 A nazajutrz weszli do Cezaryi. A Kornelijusz czekał ich, wezwawszy powinowatych swoich i bliskich przyjaciół.
-I stało się, gdy wchodził Piotr, zabieżawszy mu Kornelijusz, przypadł do nóg jego i pokłonił się.
+I stało się, gdy wchodził Piotr, zabieżawszy mu Kornelijusz, przypadł do nóg jego, i pokłonił się.
 Ale go Piotr podniósł, mówiąc: Wstań! i jamci też jest człowiek.
 A rozmawiając z nim, wszedł, a znalazł wiele tych, którzy się byli zeszli.
 I rzekł do nich: Wy wiecie, że się nie godzi mężowi Żydowinowi przyłączać albo schadzać z cudzoziemcem; lecz mnie Bóg ukazał, żebym żadnego człowieka nie nazywał pospolitym albo nieczystym.
-Przetożem też nie zbraniając się przyszedł, wezwany będąc; pytam tedy, dlaczegoście mię wezwali?
-A Kornelijusz rzekł: Od czwartego dnia aż do tej godziny pościłem, a o dziewiątej godzinie modliłem się w domu moim, a oto mąż niektóry stanął przede mną w odzieniu jasnem,
+Przetożem też niezbraniając się przyszedł, wezwany będąc; pytam tedy, dlaczegoście mię wezwali?
+A Kornelijusz rzekł: Od czwartego dnia aż do tej godziny pościłem, a o dziewiątej godzinie modliłem się w domu moim, a oto mąż niektóry stanął przedemną w odzieniu jasnem,
 I rzekł: Kornelijuszu! wysłuchana jest modlitwa twoja, a jałmużny twoje przyszły na pamięć przed obliczność Bożą.
 Przetoż poślij do Joppy, a przyzwij Szymona, którego nazywają Piotrem; ten ma gospodę w domu Szymona, garbarza, nad morzem, który przyszedłszy, mówić z tobą będzie.
 Zaraz tedy posłałem do ciebie, a tyś dobrze uczynił, żeś przyszedł. Teraz tedy jesteśmy wszyscy przed obliczem Bożem przytomni, abyśmy słuchali wszystkiego, coć rozkazano od Boga.
 Tedy Piotr otworzywszy usta, rzekł: Prawdziwie dochodzę tego, iż Bóg nie ma względu na osoby;
-Ale w każdym narodzie, kto się go boi, a czyni sprawiedliwość, jest mu przyjemnym.
+Ale w każdym narodzie, kto się go boi a czyni sprawiedliwość, jest mu przyjemnym.
 A co się tknie słowa, które posłał synom Izraelskim, opowiadając pokój przez Jezusa Chrystusa, który jest Panem wszystkiego,
 Wy wiecie, co się działo po wszystkiem Żydostwie, począwszy od Galilei, po chrzcie, który Jan opowiadał;
 Jako Jezusa z Nazaretu pomazał Bóg Duchem Świętym i mocą, który chodził, czyniąc dobrze i uzdrawiając wszystkie opanowane od dyjabła; albowiem Bóg był z nim.
 A myśmy świadkami wszystkiego tego, co czynił w krainie Judzkiej i w Jeruzalemie, którego zabili, zawiesiwszy na drzewie.
-Tego Bóg wzbudził dnia trzeciego i sprawił, żeby był objawiony;
-Nie wszystkiemu ludowi, ale świadkom przedtem sporządzonym od Boga, nam, którzyśmy z nim jedli i pili po jego zmartwychwstaniu.
-I rozkazał nam, abyśmy kazali ludowi i świadczyli, że on jest onym postanowionym od Boga sędzią żywych i umarłych.
+Tego Bóg wzbudził dnia trzeciego, i sprawił, żeby był objawiony;
+Nie wszystkiemu ludowi, ale świadkom, przedtem sporządzonym od Boga, nam, którzyśmy z nim jedli i pili po jego zmartwychwstaniu.
+I rozkazał nam, abyśmy kazali ludowi, i świadczyli, że on jest onym postanowionym od Boga sędzią żywych i umarłych.
 Temu wszyscy prorocy świadectwo wydają, iż przez imię jego odpuszczenie grzechów weźmie każdy, co weń wierzy.
 A gdy jeszcze Piotr mówił te słowa, przypadł Duch Święty na wszystkie słuchające tych słów.
 I zdumieli się oni, którzy byli z obrzezania wierzący, którzy byli z Piotrem przyszli, że i na pogany dar Ducha Świętego jest wylany.


### PR DESCRIPTION
w.7 1632 => brak przecinka ",którzy" (istnieje za "pobożnego,"), 
w.17 1632 => brak przecinków za "watpił,"; "widzenie," oraz dwukropek, zamiast przecinka za "widział:".