### PR TITLE
Łuk.7,7;14;18;23;28;41;46.

### DIFF
--- a/1879/42-luc/07.txt
+++ b/1879/42-luc/07.txt
@@ -4,28 +4,28 @@ Ten usłyszawszy o Jezusie, posłał do niego starszych z Żydów, prosząc go, 
 A oni przyszedłszy do Jezusa, prosili go z pilnością, mówiąc: Godzien jest, abyś mu to uczynił;
 Albowiem miłuje naród nasz, i on nam bóżnicę zbudował.
 A tak Jezus szedł z nimi. Ale gdy niedaleko był od domu, posłał do niego on setnik przyjacioły, mówiąc mu: Panie! nie zadawaj sobie pracy; bomci nie jest godzien, abyś wszedł pod dach mój.
-Przetoż i samego siebie nie miałem za godnego, abym miał przyjść do ciebie; ale rzecz słowo, a będzie uzdrowiony sługa mój.
+Przetoż i samego siebie nie miałem za godnego, abym był miał przyjść do ciebie; ale rzecz słowo, a będzie uzdrowiony sługa mój.
 Bomci i ja człowiek pod mocą postanowiony, mający pod sobą żołnierzy, i mówię temu: Idź, a idzie, a drugiemu: Przyjdź, a przychodzi, a słudze mojemu: Czyń to, a czyni.
 Tedy usłyszawszy to Jezus, zadziwił mu się, i obróciwszy się, rzekł do ludu, który za nim szedł: Powiadam wam, żem ani w Izraelu tak wielkiej wiary nie znalazł.
 A wróciwszy się do domu ci, którzy byli posłani, znaleźli sługę, który się źle miał, zdrowego.
 I stało się nazajutrz, że szedł do miasta, które zowią Naim, a szło z nim uczniów jego wiele i lud wielki.
 A gdy się przybliżył do bramy miejskiej, tedy oto wynoszono umarłego, syna jedynego matki swojej, a ta była wdową, a z nią szedł wielki lud miasta onego.
 Którą ujrzawszy Pan użalił się jej, i rzekł jej: Nie płacz!
-I przystąpiwszy dotknął się trumny (mar), (a ci, co nieśli, stanęli) i rzekł: Młodzieńcze! tobie mówię, wstań.
+I przystąpiwszy dotknął się trumny, (a ci, co nieśli, stanęli) i rzekł: Młodzieńcze! tobie mówię, wstań.
 I usiadł on, który był umarł, i począł mówić; i oddał go matce jego.
 Tedy wszystkich strach zdjął, a wielbili Boga, mówiąc: Prorok wielki powstał między nami, a Bóg nawiedził lud swój.
 I rozeszła się o nim ta wieść po wszystkiej Judzkiej ziemi, i po wszystkiej okolicznej krainie.
-I oznajmili Janowi uczniowie jego o tem wszystkiem. A Jan wezwawszy dwóch niektórych z uczniów swoich,
+I oznajmili Janowi uczniowie jego o tem wszystkiem. A wezwawszy dwóch niektórych z uczniów swoich,
 Posłał je do Jezusa, mówiąc: Tyżeś jest ten, który ma przyjść, czyli inszego czekać mamy?
 A gdy przyszli do niego mężowie oni, rzekli: Jan Chrzciciel posłał nas do ciebie, mówiąc: Tyżeś jest ten, który ma przyjść, czyli inszego czekać mamy?
 A onejże godziny wiele ich uzdrowił od chorób, od niemocy, i od duchów złych, i wiele ślepych wzrokiem darował.
 A odpowiadając Jezus, rzekł im: Szedłszy oznajmijcie Janowi, coście widzieli i słyszeli, iż ślepi widzą, chromi chodzą, trędowaci biorą oczyszczenie, głusi słyszą, umarli zmartwychwstają, a ubogim opowiadana bywa Ewangielija.
-A błogosławiony jest, kto by się nie zgorszył ze mnie.
+A błogosławiony jest, ktoby się nie zgorszył ze mnie.
 A gdy odeszli posłowie Janowi, począł mówić do ludu o Janie: Coście wyszli na puszczę widzieć? Izali trzcinę chwiejącą się od wiatru?
 Ale coście wyszli widzieć? Izali człowieka w miękkie szaty obleczonego? Oto ci, którzy w szatach kosztownych i w rozkoszy żyją, są w domach królewskich.
 Ale coście wyszli widzieć? Izali proroka? Zaiste powiadam wam, iż więcej niż proroka.
 Tenci bowiem jest, o którym napisano: Oto Ja posyłam Anioła mego przed obliczem twojem, który zgotuje drogę twoję przed tobą.
-Albowiem powiadam wam: Większego proroka z tych, którzy się z niewiast rodzą, nie masz nad Jana Chrzciciela żadnego; lecz kto najmniejszy jest w królestwie Bożem, większy jest, niżeli on.
+Albowiem powiadam wam: Większego proroka z tych, którzy się z niewiast rodzą, niemasz nad Jana Chrzciciela żadnego; lecz kto najmniejszy jest w królestwie Bożem, większy jest, niżeli on.
 Tedy wszystek lud słysząc to, i celnicy, wielbili Boga, będąc ochrzczeni chrztem Janowym.
 Ale Faryzeuszowie i zakonnicy pogardzili radą Bożą sami przeciwko sobie, nie będąc ochrzczeni od niego.
 I rzekł Pan: Komuż tedy przypodobam ludzi rodzaju tego, a komu są podobni?
@@ -38,12 +38,12 @@ A oto niewiasta, która była w mieście grzeszna, dowiedziawszy się, iż siedz
 A stanąwszy z tyłu u nóg jego, płacząc poczęła łzami polewać nogi jego, a włosami głowy swojej ucierała, i całowała nogi jego, i maścią mazała.
 A widząc to Faryzeusz, który go był wezwał, rzekł sam w sobie, mówiąc: Być ten był prorokiem, wiedziałby, która i jaka jest ta niewiasta, co się go dotyka; bo jest grzesznica.
 A odpowiadając Jezus, rzekł do niego: Szymonie! mam ci nieco powiedzieć, a on rzekł: Powiedz, Nauczycielu!
-Miał niektóry lichwiarz dwóch dłużników; jeden dłużen był pięćset groszy, a drugi pięćdziesiąt.
+Miał niektóry lichwiarz dwóch dłużników; jeden dłużen był pięć set groszy, a drugi pięćdziesiąt.
 A gdy oni nie mieli czem zapłacić, odpuścił obydwom. Powiedz tedy, któryż z nich bardziej go miłować będzie?
 A odpowiadając Szymon, rzekł: Mniemam, iż ten, któremu więcej odpuścił. A on mu rzekł: Dobrześ rozsądził.
 I obróciwszy się do niewiasty, rzekł Szymonowi: Widzisz tę niewiastę? Wszedłem do domu twego, nie dałeś wody na nogi moje; ale ta łzami polała nogi moje, i włosami głowy swej otarła.
 Nie pocałowałeś mię, ale ta jako weszła, nie przestała całować nóg moich.
-Nie pomazałeś oliwą głowy mojej, ale ta maścią pomazała nogi moje.
+Nie pomazałeś oliwą głowy mojej; ale ta maścią pomazała nogi moje.
 Dlaczego, mówię tobie, odpuszczono jej wiele grzechów, gdyż wiele umiłowała; a komu mało odpuszczono, mało miłuje.
 A on jej rzekł: Odpuszczone są tobie grzechy.
 I poczęli spółsiedzący mówić między sobą: Któż jest ten, który i grzechy odpuszcza?


### PR DESCRIPTION
w.14 1879 => "(mar,)" błąd w druku? - usunięto; (1632 brak) 
w.45 pozostawiono "ta" (1632) zamiast "tak" (1879)