### PR TITLE
Gal.1

### DIFF
--- a/1632/48-gal/01.txt
+++ b/1632/48-gal/01.txt
@@ -1,23 +1,23 @@
 Paweł Apoſtoł ( nie od ludźi / áni przez cżłowieká / ále przez JEzuſá CHryſtuſá y Bogá Ojcá / który go wzbudźił od umárłych ;)
-Y wszyſcy bráćia którzy ſą ze mną / Zborom Gálácſkim.
+Y wƺyſcy bráćia którzy ſą ze mną / Zborom Gálácſkim.
 Łáſká wam y pokój niech będźie od Bogá Ojcá y PAná náƺego JEzuſá CHryſtuſá.
-Który wydał ſámego śiebie zá grzechy násze / áby nas wyrwał z teráźniejƺego wieku złego / według woli Bogá y Ojcá náƺego ;
+Który wydał ſámego śiebie zá grzechy náƺe / áby nas wyrwał z teráźniejƺego wieku złego / według woli Bogá y Ojcá náƺego ;
 Któremu niech będźie chwałá ná wieki wieków / Amen.
 Dźiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
-Którá nie jeſt insza : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
+Którá nie jeſt inƺa : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
 Ale choćbyśmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąśmy wam opowiádáli / niech będźie przeklęty.
 Jákośmy przedtym powiedźieli / y teraz znowu mówię / Jesliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
-Abowiem teraz do ludźisz was námawiam / cżyli do Bogá? Albo szukamli ábym śię podobał ludźiom? Zájiſte / jeslibym śię jeszcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
+Abowiem teraz do ludźiƺ was námawiam / cżyli do Bogá? Albo ƺukamli ábym śię podobał ludźiom? Zájiſte / jeslibym śię jeƺcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
 A oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána ode mnie / nie jeſt według cżłowieká.
 Abowiem ja / ánim jey wźiął ánim śię jey náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
-Bośćie ſłyszeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
+Bośćie ſłyƺeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
 Y poſtępowałem w Żydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
 Ale gdy śię upodobáło Bogu / który mię odłącżył z żywotá mátki mojey / y powołał z łáſki ſwojey :
 Aby objáwił Syná ſwego we mnie / ábym go opowiádał między pogány / wnetże nie rádźiłem śię ćiáłá y krwie :
-Anim śię wróćił do Jeruzalem / do tych którzy przede mną byli Apoſtołámi : Alem szedł do Arábiey / y wróćiłem śię záśię do Dámászku.
-Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : y mieszkáłem u niego piętnaśćie dni.
-A inszegom z Apoſtołów nie widźiał oprócż Jákubá brátá PAńſkiego.
-A co wam piszę / oto śię przed Bogiem oświádcżam żeć nie kłamam.
-Zátymem przyszedł do krájin Syryey y Cylicyey.
+Anim śię wróćił do Jeruzalem / do tych którzy przede mną byli Apoſtołámi : Alem ƺedł do Arábiey / y wróćiłem śię záśię do Dámáƺku.
+Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : y mieƺkáłem u niego piętnaśćie dni.
+A inƺegom z Apoſtołów nie widźiał oprócż Jákubá brátá PAńſkiego.
+A co wam piƺę / oto śię przed Bogiem oświádcżam żeć nie kłamam.
+Zátymem przyƺedł do krájin Syryey y Cylicyey.
 Y byłem nieznájomym z twarzy zborom Żydowſkim / które ſą w CHryſtuśie.
-Lecż tylko byli uſłyszeli / iż ten który prześládował nas niekiedy / teraz opowiáda wiárę którą przedtym burzył: Y chwalili Bogá ze mnie.
+Lecż tylko byli uſłyƺeli / iż ten który prześládował nas niekiedy / teraz opowiáda wiárę którą przedtym burzył: Y chwalili Bogá ze mnie.

--- a/1632/48-gal/01.txt
+++ b/1632/48-gal/01.txt
@@ -5,9 +5,9 @@ Który wydał ſámego śiebie zá grzechy náƺe / áby nas wyrwał z teráźni
 Któremu niech będźie chwałá ná wieki wieków / Amen.
 Dźiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
 Którá nie jeſt inƺa : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
-Ale choćbyśmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąśmy wam opowiádáli / niech będźie przeklęty.
-Jákośmy przedtym powiedźieli / y teraz znowu mówię / Jesliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
-Abowiem teraz do ludźiƺ was námawiam / cżyli do Bogá? Albo ƺukamli ábym śię podobał ludźiom? Zájiſte / jeslibym śię jeƺcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
+Ale choćbyſmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąśmy wam opowiádáli / niech będźie przeklęty.
+Jákoſmy przedtym powiedźieli / y teraz znowu mówię / Jeſliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
+Abowiem teraz do ludźiƺ was námawiam / cżyli do Bogá? Albo ƺukamli ábym śię podobał ludźiom? Zájiſte / jeſlibym śię jeƺcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
 A oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána ode mnie / nie jeſt według cżłowieká.
 Abowiem ja / ánim jey wźiął ánim śię jey náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
 Bośćie ſłyƺeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.

--- a/1632/48-gal/01.txt
+++ b/1632/48-gal/01.txt
@@ -1,23 +1,23 @@
-Páweł / Apoſtoł ( nie od ludźi / áni przez cżłowieká / ále przez JEzuſá CHryſtuſá y Bogá Ojcá / który go wzbudźił od umárłych ; )
-Y wƺyſcy bráćiá / którzy ſą ze mną / zborom Gáláckim.
-Łáſká wám y pokój niech będźie od Bogá Ojcá y Páná náƺego JEzuſá CHryſtuſá.
-Który wydáł ſámego śiebie zá grzechy náƺe / áby náſ wyrwáł z teráźniejƺego wieku złego według woli Bogá y Ojcá náƺego ;
-Któremu niech będźie chwáłá ná wieki wieków. Amen.
-Dźiwuję śię / iż ták prędko dáćie śię przenośić od tego / który wáſ powołáł ku łáſce CHryſtuſowej / do inƺej Ewángielii ;
-Którá nie jeſt inƺą ; tylko niektórzy ſą / co wáſ turbują / y chcą wywróćić Ewángieliję CHryſtuſową.
-Ale choćbyśmy y my / álbo Anioł z niebá opowiádáł wám Ewángieliję mimo tę / którąśmy wám opowiádáli / niech będźie przeklęty.
-Jákośmy przedtem powiedźieli / y teráz znowu mówię : Jeźliby wám kto inną Ewángieliję opowiádáł mimo tę / którąśćie przyjęli / niech będźie przeklęty.
-Abowiem terázże do ludźi wáſ námáwiám / cżyli do Bogá? Albo ƺukámli / ábym śię podobáł ludźiom? Záiſte / jeźlibym śię jeƺcże ludźiom chćiáł podobáć / nie byłbym ſługą CHryſtuſowym.
-A oznájmuję wám / bráćiá! iż Ewángielijá / którá jeſt opowiádáná ode mnie / nie jeſt według cżłowieká.
-Abowiem já ánim jej wźiął / ánim śię jej náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
-Bośćie ſłyƺeli o mojem obcowániu niekiedy w Żydoſtwie / żem náder prześládowáł zbór Boży y burzyłem go ;
-Y poſtępowáłem w Żydoſtwie nád wiele rówienników moich w národźie moim / będąc náder gorliwym miłośnikiem uſtáw moich ojcżyſtych.
-Ale gdy śię upodobáło Bogu / który mię odłącżył z żywotá mátki mojej / y powołáł z łáſki ſwojej /
-Aby objáwił Syná ſwego we mnie / ábym go opowiádáł między pogánámi / wnetże nie rádźiłem śię ćiáłá y krwi ;
-Anim śię wróćił do Jeruzálemu / do tych / którzy przede mną byli Apoſtołámi / álem ƺedł do Arábii / y wróćiłem śię záśię do Dámáƺku.
-Potem po trzech látách wſtąpiłem do Jeruzálemu / ábym śię ujrzáł z Piotrem ; y mieƺkáłem u niego piętnáśćie dni.
-A inƺegom z Apoſtołów nie widźiáł / oprócż Jákóbá / brátá Páńſkiego.
-A co wám piƺę / oto śię przed Bogiem oświádcżám / żeć nie kłámię.
-Zátemem przyƺedł do kráin Syryi y Cylicyi ;
-A byłem nieznájomym z twárzy zborom Żydowſkim / które ſą w CHryſtuśie ;
-Lecż tylko byli uſłyƺeli / iż ten / który prześládowáł náſ niekiedy / teráz opowiádá wiárę / którą przedtem burzył. Y chwálili Bogá ze mnie.
+Paweł Apoſtoł ( nie od ludźi / áni przez cżłowieká / ále przez JEzuſá CHryſtuſá y Bogá Ojcá / który go wzbudźił od umárłych ;)
+Y wszyſcy bráćia którzy ſą ze mną / Zborom Gálácſkim.
+Łáſká wam y pokój niech będźie od Bogá Ojcá y PAná náƺego JEzuſá CHryſtuſá.
+Który wydał ſámego śiebie zá grzechy násze / áby nas wyrwał z teráźniejƺego wieku złego / według woli Bogá y Ojcá náƺego ;
+Któremu niech będźie chwałá ná wieki wieków / Amen.
+Dźiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
+Którá nie jeſt insza : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
+Ale choćbyśmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąśmy wam opowiádáli / niech będźie przeklęty.
+Jákośmy przedtym powiedźieli / y teraz znowu mówię / Jesliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
+Abowiem teraz do ludźisz was námawiam / cżyli do Bogá? Albo szukamli ábym śię podobał ludźiom? Zájiſte / jeslibym śię jeszcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
+A oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána ode mnie / nie jeſt według cżłowieká.
+Abowiem ja / ánim jey wźiął ánim śię jey náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
+Bośćie ſłyszeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
+Y poſtępowałem w Żydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
+Ale gdy śię upodobáło Bogu / który mię odłącżył z żywotá mátki mojey / y powołał z łáſki ſwojey :
+Aby objáwił Syná ſwego we mnie / ábym go opowiádał między pogány / wnetże nie rádźiłem śię ćiáłá y krwie :
+Anim śię wróćił do Jeruzalem / do tych którzy przede mną byli Apoſtołámi : Alem szedł do Arábiey / y wróćiłem śię záśię do Dámászku.
+Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : y mieszkáłem u niego piętnaśćie dni.
+A inszegom z Apoſtołów nie widźiał oprócż Jákubá brátá PAńſkiego.
+A co wam piszę / oto śię przed Bogiem oświádcżam żeć nie kłamam.
+Zátymem przyszedł do krájin Syryey y Cylicyey.
+Y byłem nieznájomym z twarzy zborom Żydowſkim / które ſą w CHryſtuśie.
+Lecż tylko byli uſłyszeli / iż ten który prześládował nas niekiedy / teraz opowiáda wiárę którą przedtym burzył: Y chwalili Bogá ze mnie.


### PR DESCRIPTION
W skanie wydania z 1632 roku istnieje dwuznak "ſƺ" pisany łącznie, który znaczy "sz". Zmieniłem istniejące fragmenty z "ƺ" na "sz". Możliwe że warto to automatycznie uwzględnić w całym tekście; chyba że podejście powinno być inne?
W jednym miejscu jest zamiana z "krwi" (1879) na  "krwie" (1632). Tego typu zmian nie uwzględniać?