### PR TITLE
Gal.1.

### DIFF
--- a/1632/48-gal/01.txt
+++ b/1632/48-gal/01.txt
@@ -1,23 +1,23 @@
 Paweł Apoſtoł ( nie od ludźi / áni przez cżłowieká / ále przez JEzuſá CHryſtuſá y Bogá Ojcá / który go wzbudźił od umárłych ;)
 Y wƺyſcy bráćia którzy ſą ze mną / Zborom Gálácſkim.
 Łáſká wam y pokój niech będźie od Bogá Ojcá y PAná náƺego JEzuſá CHryſtuſá.
-Który wydał ſámego śiebie zá grzechy náƺe / áby nas wyrwał z teráźniejƺego wieku złego / według woli Bogá y Ojcá náƺego ;
+Który wydał ſámego śiebie zá grzechy náƺe / áby nas wyrwał z terázniejƺego wieku złego / według woli Bogá y Ojcá náƺego.
 Któremu niech będźie chwałá ná wieki wieków / Amen.
-Dźiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
-Którá nie jeſt inƺa : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
-Ale choćbyſmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąśmy wam opowiádáli / niech będźie przeklęty.
+DZiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
+Która nie jeſt inƺa : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
+Ale choćbyſmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąſmy wam opowiádáli / niech będźie przeklęty.
 Jákoſmy przedtym powiedźieli / y teraz znowu mówię / Jeſliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
 Abowiem teraz do ludźiƺ was námawiam / cżyli do Bogá? Albo ƺukamli ábym śię podobał ludźiom? Zájiſte / jeſlibym śię jeƺcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
-A oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána ode mnie / nie jeſt według cżłowieká.
+A Oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána odemnie / nie jeſt według cżłowieká.
 Abowiem ja / ánim jey wźiął ánim śię jey náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
-Bośćie ſłyƺeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
-Y poſtępowałem w Żydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
+Bośćie ſłyƺeli o mojem obcowániu niekiedy w Zydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
+Y poſtępowałem w Zydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
 Ale gdy śię upodobáło Bogu / który mię odłącżył z żywotá mátki mojey / y powołał z łáſki ſwojey :
 Aby objáwił Syná ſwego we mnie / ábym go opowiádał między pogány / wnetże nie rádźiłem śię ćiáłá y krwie :
 Anim śię wróćił do Jeruzalem / do tych którzy przede mną byli Apoſtołámi : Alem ƺedł do Arábiey / y wróćiłem śię záśię do Dámáƺku.
-Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : y mieƺkáłem u niego piętnaśćie dni.
-A inƺegom z Apoſtołów nie widźiał oprócż Jákubá brátá PAńſkiego.
+Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : y mieƺkałem u niego piętnaśćie dni.
+A inƺegom z Apoſtołów nie widźiał ; oprócż Jákubá brátá PAńſkiego.
 A co wam piƺę / oto śię przed Bogiem oświádcżam żeć nie kłamam.
 Zátymem przyƺedł do krájin Syryey y Cylicyey.
-Y byłem nieznájomym z twarzy zborom Żydowſkim / które ſą w CHryſtuśie.
+Y byłem nieznájomym z twarzy Zborom Zydowſkim / które ſą w CHryſtuśie.
 Lecż tylko byli uſłyƺeli / iż ten który prześládował nas niekiedy / teraz opowiáda wiárę którą przedtym burzył: Y chwalili Bogá ze mnie.

--- a/1632/48-gal/01.txt
+++ b/1632/48-gal/01.txt
@@ -3,15 +3,15 @@ Y wƺyſcy bráćia którzy ſą ze mną / Zborom Gálácſkim.
 Łáſká wam y pokój niech będźie od Bogá Ojcá y PAná náƺego JEzuſá CHryſtuſá.
 Który wydał ſámego śiebie zá grzechy náƺe / áby nas wyrwał z terázniejƺego wieku złego / według woli Bogá y Ojcá náƺego.
 Któremu niech będźie chwałá ná wieki wieków / Amen.
-DZiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
+Dźiwuję śię / iż ták prętko daćie śię przenośić / od tego który was powołał ku łáſce CHryſtuſowey / do inƺey Ewángeliey.
 Która nie jeſt inƺa : tylko niektórzy ſą / co was turbują / y chcą wywróćić Ewángelią CHryſtuſowę.
 Ale choćbyſmy y my / álbo Anjoł z niebá opowiádał wam Ewángelią mimo tę którąſmy wam opowiádáli / niech będźie przeklęty.
 Jákoſmy przedtym powiedźieli / y teraz znowu mówię / Jeſliby wam kto inną Ewángelią opowiádał / mimo tę którąśćie przyjęli / niech będźie przeklęty.
 Abowiem teraz do ludźiƺ was námawiam / cżyli do Bogá? Albo ƺukamli ábym śię podobał ludźiom? Zájiſte / jeſlibym śię jeƺcże ludźiom chćiał podobáć / nie byłbym ſługą CHryſtuſowym.
-A Oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána odemnie / nie jeſt według cżłowieká.
+A oznájmuję wam bráćia / iż Ewángelia która jeſt opowiádána odemnie / nie jeſt według cżłowieká.
 Abowiem ja / ánim jey wźiął ánim śię jey náucżył od cżłowieká / ále przez objáwienie JEzuſá CHryſtuſá.
-Bośćie ſłyƺeli o mojem obcowániu niekiedy w Zydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
-Y poſtępowałem w Zydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
+Bośćie ſłyƺeli o mojem obcowániu niekiedy w Żydoſtwie : żem náder prześládował Zbór Boży / y burzyłem go.
+Y poſtępowałem w Żydoſtwie nád wiele rówienników mojich w narodźie mojim / będąc náder gorliwym miłośnikiem uſtaw mojich ojcżyſtych.
 Ale gdy śię upodobáło Bogu / który mię odłącżył z żywotá mátki mojey / y powołał z łáſki ſwojey :
 Aby objáwił Syná ſwego we mnie / ábym go opowiádał między pogány / wnetże nie rádźiłem śię ćiáłá y krwie :
 Anim śię wróćił do Jeruzalem / do tych którzy przede mną byli Apoſtołámi : Alem ƺedł do Arábiey / y wróćiłem śię záśię do Dámáƺku.
@@ -19,5 +19,5 @@ Potym po trzech lat wſtąpiłem do Jeruzalem / ábym śię ujrzał z Piotrem : 
 A inƺegom z Apoſtołów nie widźiał ; oprócż Jákubá brátá PAńſkiego.
 A co wam piƺę / oto śię przed Bogiem oświádcżam żeć nie kłamam.
 Zátymem przyƺedł do krájin Syryey y Cylicyey.
-Y byłem nieznájomym z twarzy Zborom Zydowſkim / które ſą w CHryſtuśie.
+Y byłem nieznájomym z twarzy Zborom Żydowſkim / które ſą w CHryſtuśie.
 Lecż tylko byli uſłyƺeli / iż ten który prześládował nas niekiedy / teraz opowiáda wiárę którą przedtym burzył: Y chwalili Bogá ze mnie.


### PR DESCRIPTION
Poprawa poprzedniego commita.
Nowe akapity w skanie mają dwie pierwsze litery duże - czy zmieniać tekst z 1879 na taki, aby były dwie duże litery? (np. Gal.1.11.); Jeśli małe litery, to wtedy pisać "dziwuję" czy "dźiwuję".
Pozostałe niepewne wyrazy:
W Gal.1.4. zostawiłem, tak jak w skanie: "terázniejƺego", było "teráźniejƺego" 
Gal.1.11. zostawiłem, tak jak w skanie: "odemnie"
Gal.1.13. zostawiłem, tak jak w skanie: "Zydoſtwie", było "Żydoſtwie" 
Gal.1.16. w skanie jest "miedzy", zostawiłem "między"; w skanie jest "Pogány", zostawilem "pogány"
Gal.1.19. - nie jestem pewien czy jest tam średnik (";")