### PR TITLE
Efezów.3.

### DIFF
--- a/1632/49-eph/03.txt
+++ b/1632/49-eph/03.txt
@@ -1,21 +1,21 @@
-Dlátego já Páweł jeſtem więźniem CHryſtuſá JEzuſá zá wáſ pogán ;
-Jeźliśćie tylko ſłyƺeli o udźieleniu łáſki Bożej / którá mi jeſt dáná dlá wáſ /
-Iż mi Bóg przez objáwienie oznájmił tájemnicę / ( jákom wám przedtem krótko nápiſáł :
-Skąd cżytájąc możećie obácżyć wiádomość moję w tájemnicy CHryſtuſowej. )
-Którá inƺych wieków nie byłá znájomá ſynom ludzkim / jáko teráz objáwioná jeſt świętym Apoſtołom jego y prorokom przez Duchá ;
-To jeſt / iż pogánie ſą ſpółdźiedźicámi y ſpólnem ćiáłem / y ſpółucżeſnikámi obietnicy jego w CHryſtuśie przez Ewángieliję /
-Której ſtáłem śię ſługą według dáru łáſki Bożej / którá mi jeſt dáná według ſkutku mocy jego.
-Mnie / mówię / nájmniejƺemu ze wƺyſtkich świętych dáná jeſt tá łáſká / ábym między pogánámi opowiádáł te niedośćigłe bogáctwá CHryſtuſowe /
-A iżbym objáśnił wƺyſtkim / jákáby byłá ſpołecżność onej tájemnicy zákrytej od wieków w Bogu / który wƺyſtko ſtworzył przez JEzuſá CHryſtuſá ;
-Aby teráz przez zbór wiádomá byłá kśięſtwom y mocom ná niebieśiech náder rozlicżná mądrość Bożá.
-Według poſtánowieniá wiecżnego / które ucżynił w CHryſtuśie JEzuśie / Pánu náƺym /
-W którym mámy bezpiecżność y przyſtęp z ufnośćią przez wiárę jego.
-Przetoż proƺę / ábyśćie nie ſłábieli dlá ućiſków moich zá wáſ / co jeſt chwáłą wáƺą.
-Dlátego ſkłániám koláná ſwoje przed Ojcem Páná náƺego JEzuſá CHryſtuſá /
-Z którego śię wƺelká rodźiná ná niebie y ná źiemi názywá ;
-Aby wám dáł według bogáctwá chwáły ſwej / żebyśćie byli mocą utwierdzeni przez Duchá jego w wewnętrznym cżłowieku ;
-Aby CHryſtuſ przez wiárę mieƺkáł w ſercách wáƺych ;
-Żebyśćie w miłośći wkorzenieni y ugruntowáni będąc / mogli dośćignąć ze wƺyſtkimi świętymi / którá jeſt ƺerokość / y długość / y głębokość y wyſokość ;
-Y poznáć miłość CHryſtuſową przewyżƺájącą wƺelką znájomość / ábyśćie nápełnieni byli wƺeláką zupełnośćią Bożą.
-A temu / który może náde wƺyſtko ucżynić dáleko obfićiej / niżeli prośimy álbo myślimy / według onej mocy / którá ſkutecżná jeſt w náſ ;
-Temu niech będźie chwáłá w kośćiele przez CHryſtuſá JEzuſá po wƺyſtkie cżáſy ná wieki wieków. Amen.
+Dla tego ja Páweł jeſtem więźniem CHryſtuſá JEzuſá zá was pogány.
+Jeſliśćie tylko ſłyƺeli o udźieleniu łáſki Bożey / która mi jeſt dána dla was.
+Iż mi Bóg przez objáwienie oznájmił tájemnicę ; ( jákom wam przed tym krótko nápiſał /
+Zkąd cżytájąc możećie obacżyć wiádomość moję w tájemnicy CHryſtuſowey. )
+Która inƺych wieków nie byłá znájoma ſynom ludzkim / jáko teraz objáwiona jeſt świętym Apoſtołom jego / y Prorokom / przez Duchá :
+To jeſt. Iż pogánie ſą ſpół-dźiedźicámi y ſpólnym ćiáłem / y ſpółucżeſnikámi obietnice jego w CHryſtuśie przez Ewángelią.
+Którey ſtałem śię ſługą według dáru łáſki Bożey / która mi jeſt dána / według ſkutku mocy jego.
+Mnie mówię namniejƺemu ze wƺyſtkich świętych : dána jeſt tá łáſká / ábym między pogány opowiádał te niedośćigłe bogáctwá CHryſtuſowe :
+A iżbym objáśnił wƺyſtkim jákaby byłá ſpołecżność oney tájemnice zákrytey od wieków w Bogu / który wƺyſtko ſtworzył przez JEzuſá CHryſtuſá.
+Aby teraz przez Zbór wiádoma byłá kśięſtwom y mocam ná niebieśiech náder rozlicżna mądrość Boża.
+Według poſtánowienia wiecżnego / które ucżynił w CHryſtuśie JEzuśie PAnu náƺym.
+W którym mamy beſpiecżność / y przyſtęp z dufnośćią przez wiárę jego.
+Przetoż proƺę / ábyśćie nie ſłábieli dla ućiſków mojich zá was / co jeſt chwałą wáƺą.
+Dla tego ſkłaniam koláná ſwoje przed Ojcem PAná náƺego JEzuſá CHryſtuſá ;
+Z którego śię wƺelka rodźiná ná niebie y ná źiemi názywa :
+Aby wam dał według bogáctwá chwały ſwey / żebyśćie byli mocą utwierdzeni przez Duchá jego we wnętrznym cżłowieku.
+Aby CHryſtus przez wiárę mieƺkał w ſercách wáƺych.
+Żebyśćie w miłośći wkorzenieni y ugruntowáni będąc / mogli dośćignąć ze wƺyſtkimi świętymi / która jeſt ƺerokość / y długość / y głębokość / y wyſokość ;
+Y poznáć miłość CHryſtuſowę przewyżƺájącą wƺelką znájomość ; ábyśćie nápełnieni byli wƺeláką zupełnośćią Bożą.
+A temu który może náde wƺyſtko ucżynić dáleko obfićiey niżeli prośimy / álbo myślimy / według oney mocy / która ſkutecżna jeſt w nas :
+Temu niech będźie chwałá w Kośćiele / przez CHryſtuſá JEzuſá po wƺyſtkie cżáſy ná wieki wieków / Amen.


### PR DESCRIPTION
w.11.14. wydanie z 1660 ma „Pánu” „PAná”; wydanie z 1632 ma "PANA" i "PANU".
Warto rozważyć zamienienie w całym tekście wyrazów „nas” i „was” – powtarza się zamiana „á” i „ſ” na „a” i „s”.