### PR TITLE
Hebr. 1.

### DIFF
--- a/1632/58-heb/01.txt
+++ b/1632/58-heb/01.txt
@@ -1,14 +1,14 @@
-Cżęſtokroć y wielomá ſpoſobámi máwiáł niekiedy Bóg ojcom przez proroków ;
-W te dni oſtátecżne mówił nám przez Syná ſwego / którego poſtánowił dźiedźicem wƺyſtkich rzecży / przez którego y wieki ucżynił.
-Który będąc jáſnośćią chwáły y wyráżeniem iſtnośći jego / y zátrzymując wƺyſtkie rzecży ſłowem mocy ſwojej / ocżyƺcżenie grzechów náƺych przez ſámego śiebie ucżyniwƺy / uśiádł ná práwicy májeſtátu ná wyſokośćiách /
-Tem śię zácniejƺym ſtáwƺy nád Anioły / cżem zácniejƺe nád nie odźiedźicżył imię.
-Abowiem któremuż kiedy z Aniołów rzekł : Tyś jeſt ſyn mój / jám ćię dźiś ſpłodźił? Y záśię : Já mu będę ojcem / á on mnie będźie ſynem?
-A záśię / gdy wprowádzá pierworodnego ná okrąg świátá / mówi : A niech śię mu kłániáją wƺyſcy Aniołowie Boży.
-A záśię o Aniołách mówi : Który Anioły ſwoje cżyni duchámi / á ſługi ſwoje płomieniem ogniſtym.
-Ale do Syná mówi : Stolicá twojá / o Boże! ná wieki wieków ; láſká ſpráwiedliwośći jeſt láſká króleſtwá twego.
-Umiłowáłeś ſpráwiedliwość / á nienáwidźiłeś niepráwośći ; przetoż pomázáł ćię / o Boże! Bóg twój olejkiem weſelá nád ucżeſników twoich.
-Y tyś / Pánie! ná pocżątku ugruntowáł źiemię / á niebioſá ſą dźiełem rąk twoich.
-Oneć pominą / ále ty zoſtájeƺ ; á wƺyſtkie jáko ƺátá zwiotƺeją.
+Cżęſtokroć y wielą ſpoſobów mawiał niekiedy BÓG Ojcom przez Proroki : á w te dni oſtátecżne mówił nam przez Syná <i>ſwego</i>.
+Którego poſtánowił dźiedźicem wƺyſtkich rzecży / przez którego y wieki ucżynił.
+Który będąc jáſnośćią chwały y wyráżeniem podſtáći jego / y zátrzymawájąc wƺyſtkie rzecży ſłowem mocy ſwojey / ocżyśćienie grzechów náƺych przez ſámego śiebie ucżyniwƺy / uśiadł ná práwicy májeſtatu ná wyſokośćiách.
+Tym śię zacniejƺym ſtawƺy nád Anjoły / cżym zacniejƺe nád nie odźiedźicżył Imię.
+Abowiem któremuż kiedy z Anjołów rzekł ; Tyś jeſt ſyn mój / Jam ćiebie dźiś zpłodźił? Y záśię ; Ja mu będę Ojcem / á on mnie będźie Synem?
+A záśię gdy wprowadza pierworodnego ná okrąg świátá / mówi : A niech śię mu kłaniáją wƺyſcy Anjołowie Boży.
+A záśię o Anjołách mówi ; Który Anjoły ſwoje cżyni Duchy / á ſługi ſwoje płomieniem ogniſtym.
+Ale do Syná <i>mówi</i> ; Stolicá twojá o Boże ná wieki wieków ; laſká práwośći / <i>jeſt</i> laſká króleſtwá twego.
+Umiłowałeś ſpráwiedliwość / á nienawidźiałeś niepráwośći : przetoż pomázał ćię o Boże! Bóg twój / olejkiem weſela nád ucżeſniki twoje.
+Y / Tyś PAnie ná pocżątku ugruntował źiemię / á dźiełem rąk twojich ſą niebioſá.
+Oneć pominą / ále ty zoſtawaƺ : á wƺyſtkie jáko ƺátá zwiotƺeją.
 A jáko odźienie zwinieƺ je / y będą odmienione ; ále ty tenżeś jeſt / á látá twoje nie uſtáną.
-A do któregoż kiedy z Aniołów rzekł : Siądź po práwicy mojej / dokąd nie położę nieprzyjáćiół twoich podnóżkiem nóg twoich?
-Izáli wƺyſcy nie ſą duchámi uſługującymi / którzy ná poſługę bywáją poſłáni dlá tych / którzy zbáwienie odźiedźicżyć máją?
+A do któregoż kiedy z Anjołów rzekł? Siądź po práwicy mojey / do kąd nie położę nieprzyjaćiół twojich / podnóżkiem nóg twojich.
+Izali wƺyſcy nie ſą duchámi uſługującymi / którzy ná poſługę bywáją poſłáni / dla tych którzy zbáwienie odźiedźicżyć máją?

--- a/1632/58-heb/01.txt
+++ b/1632/58-heb/01.txt
@@ -9,6 +9,6 @@ Ale do Syná <i>mówi</i> ; Stolicá twojá o Boże ná wieki wieków ; laſká 
 Umiłowałeś ſpráwiedliwość / á nienawidźiałeś niepráwośći : przetoż pomázał ćię o Boże! Bóg twój / olejkiem weſela nád ucżeſniki twoje.
 Y / Tyś PAnie ná pocżątku ugruntował źiemię / á dźiełem rąk twojich ſą niebioſá.
 Oneć pominą / ále ty zoſtawaƺ : á wƺyſtkie jáko ƺátá zwiotƺeją.
-A jáko odźienie zwinieƺ je / y będą odmienione ; ále ty tenżeś jeſt / á látá twoje nie uſtáną.
+A jáko odźienie zwinieƺ je / y będą odmienione : ále ty tenżeś jeſt / á látá twoje nie uſtáną.
 A do któregoż kiedy z Anjołów rzekł? Siądź po práwicy mojey / do kąd nie położę nieprzyjaćiół twojich / podnóżkiem nóg twojich.
 Izali wƺyſcy nie ſą duchámi uſługującymi / którzy ná poſługę bywáją poſłáni / dla tych którzy zbáwienie odźiedźicżyć máją?


### PR DESCRIPTION
w.1,2. istnieje różnica w znakowaniu początku wersetu 2. Przyjęto wersję z 1632 oraz 1660 
w.1. "niekiedy" razem => 1660