### PR TITLE
1 Kor.6.

### DIFF
--- a/1632/46-cor/06.txt
+++ b/1632/46-cor/06.txt
@@ -1,20 +1,20 @@
-Śmież kto z was / májąc ſpráwę z drugim / ſądźić śię przed nieſpráwiedliwymi / á nie przed świętymi?
-Azáż nie wiećie / iż święći będą ſądźili świát? A jeſli świát od was będźie ſądzony / cżyliśćie niegodni / ábyśćie ſądy mniejƺe odpráwiáli?
-Azáż nie wiećie / iż Anioły ſądźić będźiemy? A cóż tych docżeſnych rzecży?
-Przeto jeſlibyśćie mieli ſądy o rzecży docżeſne / tych / którzy ſą nájpodlejśi we zborze / ná ſąd wyſádzájćie.
-Ku záwſtydzeniu wáƺemu to mówię. Niemáƺże między wámi mądrego y jednego / któryby mógł rozſądźić między bráćmi ſwoimi?
-Ale śię brát z brátem práwuje / y to przed niewiernymi?
-Już tedy zápewne jeſt między wámi niedoſtátek / że śię z ſobą práwujećie. Cżemuż rácżej krzywdy nie ćierpićie? Cżemuż rácżej ƺkody nie podejmujećie?
-Owƺem wy krzywdźićie y do ƺkody przywodźićie / á to bráći.
-Azáż nie wiećie / iż nieſpráwiedliwi króleſtwá Bożego nie odźiedźicżą? Nie mylćie śię : áni wƺetecżnicy / áni báłwochwálcy / áni cudzołożnicy / áni pieƺcżotliwi / áni ſámcołożnicy /
+Śmież kto z was májąc ſpráwę z drugim / ſądźić śię przed nieſpráwiedliwymi / á nie przed świętymi?
+Azaż nie wiećie / iż święći będą ſądźili świát? A jeſli świát od was będźie ſądzony ; cżyliśćie niegodni / ábyśćie ſądy mniejƺe odpráwowáli?
+Azaż nie wiećie / iż Anjoły ſądźić będźiemy? A cóż <i>tych</i> docżeſnych rzecży?
+Przeto jeſlibyśćie mieli ſądy o rzecży docżeſne / tych którzy ſą napodlejƺy we Zborze / ná ſąd wyſadzajćie.
+Ku záwſtydzeniu wáƺemu to mówię. Niemáƺże między wámi mądrego y jednego / któryby mógł rozſądźić między bráćią ſwoją?
+Ale śię brát z brátem práwuje ; y to przed niewiernymi.
+Już tedy zápewne jeſt między wámi niedoſtátek / że śię z ſobą práwujećie. Cżemuż rácżey krzywdy nie ćierpićie? Cżemuż rácżey ƺkody nie podejmujećie?
+Owƺem wy krzywdźićie ; y do ƺkody przywodźićie ; á to bráćią.
+Azaż nie wiećie / iż nieſpráwiedliwi króleſtwá Bożego nie odźiedźicżą? Nie mylćie śię ; áni wƺetecżnicy / áni báłwochwálcy / áni cudzołożnicy / áni pieƺcżotliwi / áni ſámcołożnicy /
 Ani złodźieje / áni łákomcy / áni pijánicy / áni złorzecżący / áni źdźiercy króleſtwá Bożego nie odźiedźicżą.
-A tákimiśćie niektórzy byli ; áleśćie omyći / áleśćie poświęceni / áleśćie uſpráwiedliwieni w imieniu Páná JEzuſá / y przez Duchá Bogá náƺego.
-Wƺyſtko mi wolno / ále nie wƺyſtko pożytecżno ; wƺyſtko mi wolno / ále ja śię nie dám zniewolić żádney rzecży.
-Pokármy brzuchowi náleżą / á brzuch pokármom ; ále Bóg y brzuch y pokármy ſkáźi ; lecż ćiáło nie náleży wƺetecżeńſtwu / ále Pánu / á Pán ćiáłu.
-Bo Bóg y Páná wzbudźił / y nas wzbudźi mocą ſwoją.
-Azáż nie wiećie / iż ćiáłá wáƺe ſą cżłonkámi CHryſtuſowymi? Wźiąwƺy tedy cżłonki CHryſtuſowe / cżyli je ucżynię cżłonkámi wƺetecżnicy? Nie dáj tego Boże!
-Azáż nie wiećie / iż ten / co śię złącżá z wƺetecżnicą / jednem ćiáłem z nią jeſt? ábowiem mówi : Będą dwoje jednem ćiáłem.
-A kto śię złącżá z Pánem / jednym duchem jeſt z nim.
-Ućiekájćie przed wƺetecżeńſtwem. Wƺelki grzech / któryby cżłowiek popełnił / oprócż ćiáłá jeſt ; lecż kto wƺetecżeńſtwo płodźi / przećiwko ſwemu włáſnemu ćiáłu grzeƺy.
-Azáż nie wiećie / iż ćiáło wáƺe jeſt kośćiołem Duchá Świętego / który w was jeſt / którego máćie od Bogá? á nie jeſteśćie ſámi ſwoi ;
-Abowiemeśćie drogo kupieni. Wyſłáwiájćież tedy Bogá w ćiele wáƺem y w duchu wáƺym / które ſą Boże.
+A tákimiśćie niektórzy byli : Aleśćie omyći / áleśćie poświęceni / áleśćie uſpráwiedliwieni w Imieniu PAná JEzuſá / y przez Duchá Bogá náƺego.
+Wƺyſtko mi wolno ; ále nie wƺyſtko pożytecżno. Wƺyſtko mi wolno ; ále ja śię nie dam zniewolić żadney rzecży.
+Pokármy brzuchowi <i>należą</i> , á brzuch pokármom : ále Bóg y brzuch y pokármy ſkáźi. Lecż ćiáło nie <i>należy</i> wƺetecżeńſtwu / ále PAnu ; á PAn ćiáłu.
+Bo Bóg y PAná wzbudźił / y nas wzbudźi mocą ſwoją.
+Azaż nie wiećie iż ćiáłá wáƺe ſą cżłonkámi CHryſtuſowymi? Wźiąwƺy tedy cżłonki CHryſtuſowe / cżyli je ucżynię cżłonkámi wƺetecżnice? Nie daj tego Boże!
+Azaż nie wiećie / iż ten co śię złącża z wƺetecżnicą / jednym ćiáłem <i>z nią</i> jeſt? Abowiem mówi ; Będą dwoje jednym ćiáłem.
+A kto śię złącżá z PAnem / jednym duchem jeſt <i>z nim</i>.
+Ućiekajćie przed wƺetecżeńſtwem. Wƺelki grzech / któryby cżłowiek popełnił / oprócż ćiáłá jeſt : lecż kto wƺetecżeńſtwo płodźi / przećiwko ſwemu właſnemu ćiáłu grzeƺy.
+Azaż nie wiećie / iż ćiáło wáƺe jeſt kośćiołem Duchá Świętego <i>który</i> w was jeſt / którego maćie od Bogá / á nie jeſteśćie ſámi ſwoji :
+Abowiemeśćie drogo kupieni. Wyſławiajćież tedy Bogá w ćiele wáƺym y w duchu wáƺym / które ſą Boże.


### PR DESCRIPTION
w.16. „Azaż” najpewniej literówka – brak „ż” 