### PR TITLE
1 Kor.11.

### DIFF
--- a/1632/46-cor/11.txt
+++ b/1632/46-cor/11.txt
@@ -1,34 +1,34 @@
-Bądźćie náśládowcámi moimi / jákom y ja CHryſtuſowy ;
-A chwálę was / bráćia! iż pámiętáćie wƺyſtkie moje náuki / á jákom wám podáł / podániá trzymáćie.
-A chcę / ábyśćie wiedźieli / iż káżdego mężá głową jeſt CHryſtuſ / á głową niewiáſty mąż / á głową CHryſtuſową Bóg.
-Káżdy mąż / gdy śię modli álbo prorokuje z przykrytą głową / ƺpeći głowę ſwoję.
-Y káżdá niewiáſtá / gdy śię modli álbo prorokuje / nie nákrywƺy głowy ſwojey / ƺpeći głowę ſwoję ; boć to jedno á toż ſámo jeſt / jákoby ogoloná byłá.
-Abowiem jeſli śię nie nákrywá niewiáſtá / niechże śię też ſtrzyże ; á jeſli ƺpetná rzecż jeſt niewieśćie / ſtrzydz śię álbo golić / niechże śię nákrywá.
-Abowiem mąż nie má nákrywáć głowy / gdyż jeſt wyobráżeniem y chwáłą Bożą ; ále niewiáſtá jeſt chwáłą mężową.
+Bądźćie náśládowcámi mojimi / jákom y ja CHryſtuſów.
+A chwalę was bráćia / iż pámiętaćie wƺyſtkie moje <i>náuki,</i> á jákom wam podał / podánia trzymaćie.
+A chcę ábyśćie wiedźieli / iż káżdego mężá głową jeſt CHryſtus / á głową niewiaſty mąż / á głową CHryſtuſową Bóg.
+Káżdy mąż gdy śię modli álbo prorokuje z przykrytą głową / ƺpeći głowę ſwoję.
+Y káżda niewiáſtá gdy śię modli álbo prorokuje nie nákrywƺy głowy ſwojey / ƺpeći głowę ſwoję : boć to jedno / á toż jeſt jákoby ogolona byłá.
+Abowiem jeſli śię nie nákrywa niewiáſtá / niechże śię też ſtrzyże. A jeſli ƺpetna rzecż jeſt niewieśćie ſtrzydz śię álbo golić / niechże śię nákrywa.
+Abowiem mąż nie ma nákrywáć głowy ; gdyż jeſt wyobráżeniem y chwałą Bożą ; ále niewiáſtá jeſt chwałą mężową.
 Bo mąż nie jeſt z niewiáſty / ále niewiáſtá z mężá.
 Abowiem mąż nie jeſt ſtworzony dla niewiáſty / ále niewiáſtá dla mężá.
-A przetoż niewiáſtá powinná mieć włádzę ná głowie dla Aniołów.
-A wƺákże mąż nie jeſt bez niewiáſty / áni niewiáſtá nie jeſt bez mężá w Pánu.
-Abowiem jáko niewiáſtá z mężá jeſt / ták też mąż przez niewiáſtę ; jednák wƺyſtkie rzecży ſą z Bogá.
-Sámi u śiebie rozſądźćie / przyſtoili niewieśćie bez nákryćiá modlić śię Bogu?
-Azáż was y ſámo przyrodzenie nie ucży / iż mężowi / gdyby włoſy zápuƺcżáł / jeſt mu ku zelżywośći?
-Ale niewiáſtá / jeſli zápuƺcżá włoſy / jeſt jey ku pocżćiwośći / przeto / iż jey włoſy dáne ſą zá przykryćie.
-A jeſliby śię kto zdáł być ſwárliwym / my tákiego obycżáju nie mámy / áni zbory Boże.
-A to opowiádájąc / nie chwálę / że śię nie ku lepƺemu / ále ku gorƺemu ſchodźićie.
-Abowiem nájprzód / gdy śię wy ſchodźićie we zborze / ſłyƺę / iż rozerwániá bywáją między wámi / y poniekąd wierzę.
-Boć muƺą być kácerſtwá między wámi / áby ći / którzy ſą doświádcżeni / byli jáwnymi między wámi.
-Gdy śię wy tedy weſpół ſchodźićie / nie jeſt to używáć wiecżerzy Páńſkiej.
-Abowiem káżdy wiecżerzę ſwoję pierwej zjádá / y jeden łáknie á drugi jeſt pijány.
-Azáż domów nie máćie do jedzeniá y do pićiá? Albo zborem Bożym gárdźićie y záwſtydzáćie tych / którzy nie máją? Cóż wám rzekę? Pochwálęż was? W tem nie chwálę.
-Abowiem jám wźiął od Páná / com też wám podáł / iż Pán JEzuſ tey nocy / którey był wydán / wźiął chleb /
-A podźiękowáwƺy / złámáł y rzekł : Bierzćie / jedzćie ; to jeſt ćiáło moje / które zá was bywá łámáne ; to cżyńćie ná pámiątkę moję.
-Tákże y kielich / gdy było po wiecżerzy / mówiąc : Ten kielich jeſt nowy teſtáment we krwi mojey ; to cżyńćie / ile kroć pić będźiećie / ná pámiątkę moję
-Abowiem ilekroćbyśćie jedli ten chleb / y ten kielichbyśćie pili / śmierć Páńſką opowiádájćie / áżby przyƺedł.
-A ták / ktoby jádł ten chleb / álbo pił ten kielich Páńſki niegodnie / będźie winien ćiáłá y krwi Páńſkiej.
-Niechże tedy cżłowiek ſámego śiebie doświádcży / á ták niech je z chlebá tego / y z kielichá tego niecháj pije.
-Abowiem kto je y pije niegodnie / ſąd ſobie ſámemu je y pije / nie rozſądzájąc ćiáłá Páńſkiego.
-Dlátego między wámi wiele jeſt ſłábych y chorych / y niemáło ich záſnęło.
-Bo gdybyśmy śię ſámi rozſądzáli / nie bylibyśmy ſądzeni.
-Lecż gdy ſądzeni bywámy / od Páná bywámy ćwicżeni / ábyśmy z świátem nie byli potępieni.
-Ale ták / bráćia moi! gdy śię ſchodźićie ku jedzeniu / ocżekiwájćie jedni drugich.
-A jeſli kto łáknie / niechże je w domu / ábyśćie śię ná ſąd nie ſchodźili. A inne rzecży / gdy przyjdę / poſtánowię.
+A przetoż niewiáſtá powinna mieć władzą ná głowie / dla Anjołów.
+A wƺákże mąż nie jeſt bez niewiáſty / áni niewiáſtá nie <i>jeſt</i> bez mężá w PAnu.
+Abowiem jáko niewiáſtá z mężá jeſt / ták też mąż przez niewiáſtę : jednák wƺyſtkie rzecży ſą z Bogá.
+Sámi u śiebie rozſądźćie / przyſtojili niewieśćie bez nákryćia modlić śię Bogu.
+Azaż was y ſámo przyrodzenie nie ucży / iż mężowi / gdyby włoſy zápuƺcżał / jeſt mu ku zelżywośći.
+Ale niewiáſtá jeſli zápuƺcża włoſy / jeſt jey ku pocżćiwośći ; przeto iż jey włoſy dáne ſą zá przykryćie.
+A jeſliby śię kto zdał być ſwarliwym ; my tákiego obycżáju nie mamy / áni Zbory Boże.
+A to opowiádájąc / nie chwalę / że śię nie ku lepƺemu ále ku gorƺemu zchodźićie.
+Abowiem naprzód gdy śię wy zchodźićie we Zborze / ſłyƺę iż rozerwánia bywáją między wámi ; y poniekąd wierzę.
+Boć muƺą być kácerſtwá między wámi / áby ći którzy ſą doświadcżeni / byli jáwnymi między wámi.
+Gdy śię wy tedy weſpół zchodźićie / nie jeſt to używáć Wiecżerzy PAńſkiey.
+Abowiem káżdy wiecżerzą ſwoję pierwey zjada / y jeden łáknie / á drugi jeſt pijány.
+Azaż domów nie maćie do jedzenia y do pićia? Albo Zborem Bożym gárdźićie / y záwſtydzaćie te którzy nie máją? Cóż wam rzekę? Pochwalęż was? W tym nie chwalę.
+Abowiem jam wźiął od PAná com też wam podał : Iż PAN JEzus tey nocy którey był wydan / wźiął chleb :
+A podźiękowawƺy złamał / y rzekł : Bierzćie / jedzćie ; To jeſt ćiáło moje które zá was bywa łamáne : to cżyńćie ná pámiątkę moję.
+Tákże y kielich gdy było po wiecżerzy / mówiąc : Ten kielich jeſt nowy Teſtáment we krwi mojey : to cżyńćie / ile kroć pić będźiećie ná pámiątkę moję.
+Abowiem ilekroćbyśćie jedli ten chleb / y ten kielichbyśćie pili / śmierć PAńſką opowiádajćie / áżby przyƺedł.
+A ták ktoby jadł ten chleb álbo pił ten kielich PAńſki niegodnie / będźie winien ćiáłá y krwie PAńſkiey.
+Niechże tedy cżłowiek ſámego śiebie doświadcży / á ták niech je z chlebá <i>tego,</i> y z kielichá tego niechaj pije.
+Abowiem kto je y pije niegodnie / ſąd ſobie ſámemu je y pije / nie rozſądzájąc ćiáłá PAńſkiego.
+Dla tego między wámi wiele jeſt ſłábych y chorych / y nie máło ich záſnęło.
+Bo gdybyſmy śię ſámi rozſądzáli / nie bylibyſmy ſądzeni.
+Lecż gdy ſądzeni bywamy / od PAná bywamy ćwicżeni / ábyſmy z świátem nie byli potępieni.
+A ták bráćia moji / gdy śię zchodźićie ku jedzeniu / ocżekawajćie jedni drugich.
+A jeſli kto łáknie / niechże je domá ; ábyśćie śię ná ſąd nie zchodźili. A inne <i>rzecży</i> gdy przydę / poſtánowię.


### PR DESCRIPTION
Zauważyłem brak konsekwencji w używaniu słowa "północy": w skanie raz jest "pułnocy" a raz "północy", podobnie jest z słowem rękách -> rękách/ręku
Powtarzające się zamiany - reguła że słowo pán w odniesieniu do człowieka ma pierwszą literę dużą:
pán -> Pan
páná -> Páná
pánie -> Pánie
pánu -> Pánu

odtąd -> od tąd
dotąd -> do tąd
ustách -> uśćiech (wyjątek stanowi Psalm 149,6 ale skoro w reszcie miejsc jest zamiana to można uznać ten wyjątek za błąd)
przećie -> przećię
przećież -> przećię
