### PR TITLE
Dźieje 2.

### DIFF
--- a/1632/44-act/02.txt
+++ b/1632/44-act/02.txt
@@ -1,47 +1,47 @@
 A gdy przyƺedł dźień pięćdźieśiąty / byli wƺyſcy jednomyślnie poſpołu.
-Tedy śię ſtáł z prędká z niebá ƺum / jákoby przypádájącego wiátru gwáłtownego / y nápełnił wƺyſtek dom / kędy śiedźieli.
-Y ukázáły śię im rozdźielone języki ná kƺtáłt ogniá / który uśiádł ná káżdym z nich.
-Y nápełnieni ſą wƺyſcy Duchem Świętym / á pocżęli mówić innemi językámi / jáko im Duch on dáwáł wymáwiáć.
-A byli w Jeruzálemie mieƺkájący Żydowie / mężowie nábożni / z káżdego národu tych / którzy ſą pod niebem.
-A gdy śię ſtáł ten głoſ / zeƺło śię mnóſtwo ludźi / y ſtrwożyli śię / że je ſłyƺáł káżdy z nich mówiące włáſnym językiem ſwoim.
-Y zdumiewáli śię wƺyſcy / y dźiwowáli śię / mówiąc jedni do drugich : Izáli oto ći wƺyſcy / którzy mówią / nie ſą Gálilejcżycy?
-A jákoż my od nich ſłyƺymy káżdy z nas ſwój włáſny język / w którymeśmy śię urodźili?
-Pártowie y Medowie / y Elámitowie / y którzy mieƺkámy w Mezopotámii / w Judzkiej źiemi / y w Kápádocyi / w Ponćie / y w Azyi ;
-W Frygii / y w Pámfilii / w Egipćie / y w ſtronách Libii / która jeſt podle Cyreny / y przychodniowie Rzymſcy ; Żydowie / y nowonáwróceni ;
-Kreteńcżycy / y Arábcżycy ; ſłyƺymy ich / mówiących językámi náƺemi wielkie ſpráwy Boże.
-Y zdumiewáli śię wƺyſcy / y dźiwowáli śię / mówiąc jeden do drugiego : Cóż to wżdy má być?
-Lecż drudzy náśmiewájąc śię / mówili : Ci śię młodem winem popili.
-A ſtánąwƺy Piotr z jedenáſtomá / podnióſł głoſ ſwój / y przemówił do nich : Mężowie Judzcy / y wƺyſcy / którzy mieƺkáćie w Jeruzálemie! niech wám to jáwno będźie / á przyjmijćie w uƺy ſłowá moje.
-Abowiem nie ſą ći / jáko wy mniemáćie / pijáni / gdyż dopiero jeſt trzećiá ná dźień godźiná.
-Aleć to jeſt ono / co przepowiedźiáno przez proroká Joelá :
-Y będźie w oſtátecżne dni / ( mówi Bóg : ) Wyleję z Duchá mego ná wƺelkie ćiáło / á prorokowáć będą ſynowie wáśi y córki wáƺe / á młodźieńcy wáśi widzeniá widźieć będą / á ſtárcom wáƺym ſny śię śnić będą.
-Náwet w oneż dni ná ſługi moje y ná ſłużebnice moje wyleję z Duchá mego / y będą prorokowáć ;
-Y ukáżę cudá ná niebie w górze / y známioná ná źiemi niſko / krew / y ogień / y párę dymu.
-Słońce śię obróći w ćiemność / á kśiężyc w krew / przedtem niż przyjdźie on dźień Páńſki wielki y znácżny.
-Y ſtánie śię / że ktobykolwiek wzywáł imieniá Páńſkiego / zbáwion będźie.
-Mężowie Izráelſcy! ſłuchájćie ſłów tych JEzuſá / onego Názáreńſkiego / mężá od Bogá wſłáwionego u was mocámi y cudámi / y známionámi / które cżynił Bóg przezeń w pośrodku was / jáko y wy ſámi wiećie ;
-Tego zá ułożoną rádą y przejrzeniem Bożem wydánego wźiąwƺy á przez ręce niezbożników ukrzyżowáwƺy / zábiliśćie.
-Którego Bóg wzbudźił / rozwiązáwƺy boleśći śmierći / jákoż było to niepodobne / áby od niej miał być zátrzymány.
-Abowiem o nim mówi Dawid : Upátrywáłem záwƺe Páná przed oblicżem mojem ; bo mi jeſt po práwicy / ábym nie był wzruƺony.
-Przetoż rozweſeliło śię ſerce moje / y rozrádowáł śię język mój / nádto y ćiáło moje odpocżnie w nádźiei ;
-Abowiem nie zoſtáwiƺ duƺy mojey w piekle / á nie dáƺ świętemu twojimu oglądáć ſkáżeniá.
+Tedy śię ſtał z prętká z niebá ƺum / jákoby przypadájącego wiátru gwałtownego ; y nápełnił wƺyſtek dom kędy śiedźieli.
+Y ukazáły śię im rozdźielone języki ná kƺtałt ogniá / który uśiadł ná káżdym z nich.
+Y nápełnieni ſą wƺyſcy Duchem Świętym / á pocżęli mówić innymi językámi / jáko im Duch on dawał wymawiáć.
+A byli w Jeruzalem mieƺkájący Żydowie mężowie nabożni z káżdego narodu tych którzy <i>ſą</i> pod niebem.
+A gdy śię ſtał ten głos / zeƺło śię mnóſtwo <i>ludźi</i> ; y ztrwożyli śię / że je ſłyƺał káżdy z nich mówiące właſnym językiem ſwojim.
+Y zdumiewáli śię wƺyſcy / y dźiwowáli śię mówiąc jedni do drugich : Izali oto ći wƺyſcy którzy mówią / nie ſą Gálilejcżycy?
+A jákoż my <i>od nich</i> ſłyƺymy káżdy z nas ſwój właſny język / w którymeſmy śię urodźili?
+Pártowie / y Medowie / y Elámitowie / y którzy mieƺkamy w Meſopotámiey / w Judſkiey źiemi / y w Káppádociey / w Ponćie y w Azyey :
+W Frygiey y w Pámfyliey / w Egipćie / y w ſtronách Libiey / która jeſt podle Cyreny / y przychodniowie Rzymſcy : Żydowie / y nowo náwróceni :
+Kreteńcżycy / y Arábcżycy / ſłyƺymy je mówiące językámi náƺymi wielkie ſpráwy Boże.
+Y zdumiewáli śię wƺyſcy / y dźiwowáli śię / mówiąc jeden do drugiego : Cóż to wżdy ma bydź?
+Lecż drudzy náśmiewájąc śię mówili : Ci śię młodym winem popili.
+A ſtánąwƺy Piotr z jedenaśćią / podnióſł głos ſwój / y przemówił do nich : Mężowie Judſcy / y wƺyſcy którzy mieƺkaćie w Jeruzalem / niech wam to jáwno będźie / á przyjmićie w uƺy ſłowá moje.
+Abowiem nie ſą ći / jáko wy mniemaćie / pijáni : gdyż dopiero jeſt trzećia ná dźień godźiná :
+Aleć to jeſt ono co przepowiedźiano przez Proroká Joelá :
+Y będźie w oſtátecżne dni ( mówi BÓG ) Wyleję z Duchá mego ná wƺelkie ćiáło : á prorokowáć będą ſynowie wáƺy y córki wáƺe : á młodźieńcy wáƺy widzenia widźieć będą ; á ſtárcom wáƺym ſny śię ſnić będą.
+Náwet w oneż dni / ná ſługi moje y ná ſłużebnice moje / wyleję z Duchá mego / y będą prorokowáć.
+Y ukażę cudá ná niebie wzgórę / y známioná ná źiemi niſko / krew / y ogień / y párę dymu.
+Słońce śię obróći w ćiemność / á kśiężyć w krew / przed tym niż przydźie on dźień PAńſki wielki y znácżny.
+Y ſtánie śię / <i>że</i> ktobykolwiek wzywał Imienia PAńſkiego zbáwion będźie.
+Mężowie Izráelſcy / ſłuchajćie ſłów tych. JEzuſá onego Názáreńſkiego / mężá od Bogá wſławionego u was mocámi y cudámi / y známionámi / które cżynił Bóg przezeń w pośrzodku was / jáko y wy ſámi wiećie :
+Tego zá ułożoną rádą y przejrzeniem Bożym wydánego wźiąwƺy / <i>á</i> przez ręce niezbożników ukrzyżowawƺy / zábiliśćie :
+Którego Bóg w zbudźił / rozwiązawƺy boleśći śmierći ; jákoż byłá to nie podobna / áby od niey miał być zátrzymány.
+Abowiem o nim mówi Dawid : Upátrowałem záwżdy PAná przed oblicżem mojim ; bo mi jeſt po práwicy / ábym nie był wzruƺony.
+Przetoż rozweſeliło śię ſerce moje / y rozrádował śię język mój : nád to / y ćiáło moje odpocżynie w nádźiejey.
+Abowiem nie zoſtáwiƺ duƺe mojey w grobie / á nie daƺ świętemu twojemu oglądáć ſkáżenia.
 Oznájmiłeś mi drogi żywotá / á nápełniƺ mię rádośćią przed oblicżem twojim.
-Mężowie bráćia! mogę bezpiecżnie mówić do was o pátryjárƺe Dawidźie / żeć umárł y pogrzebiony jeſt / á grób jego jeſt u nas áż do dniá dźiśiejƺego.
-Będąc tedy prorokiem / y wiedząc / że mu śię Bóg obowiązáł przyśięgą / iż z owocu biódr jego według ćiáłá miał wzbudźić CHryſtuſá / á poſádźić ná ſtolicy jego.
-To przeglądájąc / powiedźiáł o zmartwychwſtániu CHryſtuſowem / iż nie zoſtáłá duƺá jego w piekle / áni ćiáło jego widźiáło ſkáżeniá.
-Tegoć JEzuſá wzbudźił Bóg / cżego my wƺyſcy jeſteśmy świádkámi.
-Práwicą tedy Bożą będąc wywyżƺony / á obietnicę Duchá Świętego wźiąwƺy od Ojcá / wyláł to / co wy teraz widźićie y ſłyƺyćie.
-Abowiemći Dawid nie wſtąpił do niebá / lecż ſám powiádá : Rzekł Pán Pánu memu / śiądź po práwicy mojey /
-Aż położę nieprzyjáćioły twoje podnóżkiem nóg twoich.
-Niechájże tedy wie zápewne wƺyſtek dom Izráelſki / że go Bóg y Pánem y CHryſtuſem ucżynił / tego JEzuſá / któregośćie wy ukrzyżowáli.
-A to ſłyƺąc / przeráżeni ſą ná ſercu / y rzekli do Piotrá y do innych Apoſtołów : Cóż mámy cżynić / mężowie bráćia?
-Tedy Piotr rzekł do nich : Pokutujćie / á ochrzćij śię káżdy z was w imieniu JEzuſá CHryſtuſá ná odpuƺcżenie grzechów / á weźmiećie dár Duchá Świętego.
-Abowiemći wám tá obietnicá náleży y dźiátkom wáƺym / y wƺyſtkim / którzy dáleko ſą / którebykolwiek powołáł Pán / Bóg náƺ.
-Y wielą inƺych ſłów oświádcżáł śię / y nápomináł je / mówiąc : Wyzwólćie śię od tego rodzáju przewrotnego.
-Którzy tedy wdźięcżnie przyjęli ſłowá jego / ochrzcżeni ſą / y przyſtáło dniá onego duƺ około trzech tyśięcy.
-Y trwáli w náuce Apoſtolſkiej y w ſpołecżnośći y w łámániu chlebá y w modlitwách.
-Y przyƺedł ſtrách ná káżdą duƺę / á wiele śię známion y cudów przez Apoſtołów dźiáło.
-A wƺyſcy / którzy uwierzyli byli poſpołu / y wƺyſtkie rzecży mieli ſpólne.
-A ośiádłośći y májętnośći ſprzedáwáli / y udźieláli ich wƺyſtkim / jáko komu było potrzebá.
-A ná káżdy dźień trwájąc zgodnie w kośćiele / y chleb łámiąc po domách / przyjmowáli pokárm z rádośćią / y w proſtoćie ſerdecżney.
-Chwáląc Bogá / y májąc łáſkę u wƺyſtkiego ludu. A Pán przydáwáł zborowi ná káżdy dźień tych / którzy mieli być zbáwieni.
+Mężowie bráćia / mogę beſpiecżnie mówić do was o Pátryárƺe Dawidźie / żeć umárł y pogrzebiony jeſt / á grób jego jeſt u nas áż do dniá dźiśiejƺego.
+Będąc tedy Prorokiem / y wiedząc że mu śię Bóg obowiązał przyśięgą / <i>yż</i> z owocu biódr jego / według ćiáłá miał wzbudźić CHryſtuſá / á poſádźić ná ſtolicy jego.
+<i>To</i> przeglądájąc / powiedźiał o zmartwychwſtániu CHryſtuſowym / iż nie zoſtáłá duƺá jego w grobie / áni ćiáło jego widźiáło ſkáżenia.
+Tegoć JEzuſá wzbudźił Bóg : cżego my wƺyſcy jeſteſmy świádkámi.
+Práwicą tedy Bożą <i>będąc</i> wywyżƺony / á obietnicę Duchá Świętego wźiąwƺy od Ojcá / wylał to co wy teraz widźićie y ſłyƺyćie.
+Abowiemći Dawid nie wſtąpił do niebá / lecż ſam powiáda ; Rzekł PAN PAnu memu / śiądź po práwicy mojey :
+Aż położę nieprzyjaćioły twoje podnóżkiem nóg twojich.
+Niechajże tedy wie zápewne wƺyſtek dom Izráelſki / że go Bóg y PAnem y CHryſtuſem ucżynił / tego JEzuſá / któregośćie wy ukrzyżowáli.
+A to ſłyƺąc / przeráżeni ſą ná ſercu / y rzekli do Piotrá y do innych Apoſtołów ; Cóż mamy cżynić mężowie bráćia?
+Tedy Piotr rzekł do nich ; Pokutujćie / á ochrzći śię káżdy z was w Imieniu JEzuſá CHryſtuſá / ná odpuƺcżenie grzechów ; á weźmiećie dar Duchá Świętego.
+Abowiemći wam tá obietnicá należy / y dźiatkom wáƺym / y wƺyſtkim którzy dáleko <i>ſą,</i> którebykolwiek powołał PAn Bóg náƺ.
+Y wielą inƺych ſłów oświadcżał śię / y nápominał <i>je</i> mówiąc ; Wyzwólćie śię od tego rodzáju przewrotnego.
+Którzy tedy wdźięcżnie przyjęli ſłowá jego / ochrzcżeni ſą : y przyſtáło dniá onego duƺ około trzech tyśięcy.
+Y trwáli w náuce Apoſtolſkiey / y w ſpołecżnośći / y w łamániu chlebá / y w modlitwách.
+Y przyƺedł ſtrách ná káżdą duƺę / á wiele śię známion y cudów przez Apoſtoły dźiało.
+A wƺyſcy którzy uwierzyli / byli poſpołu : y wƺyſtkie rzecży mieli ſpólne.
+A ośiádłośći y májętnośći przedawáli ; y udźieláli ich wƺyſtkim / jáko komu było potrzebá.
+A ná káżdy dźień trwájąc zgodnie w kośćiele / y chleb łamiąc po domách / przyjmowáli pokarm z rádośćią / y w proſtoćie ſerdecżney :
+Chwaląc Bogá / y májąc łáſkę u wƺyſtkiego ludu. A PAN przydawał Zborowi ná káżdy dźień tych / którzy mieli być zbáwieni.


### PR DESCRIPTION
w.27, 31: wg 1632, 1660 skorygowano "piekło" na "grób", jednak wg BB, TR, KJV jest "piekło" = "ᾅδηνς" (86)