### PR TITLE
1 Moj. 2.

### DIFF
--- a/1632/01-gen/02.txt
+++ b/1632/01-gen/02.txt
@@ -1,25 +1,25 @@
-Dokońcżone tedy ſą niebioſá y źiemiá / y wƺyſtko wojſko ich.
-Y dokońcżył Bóg dniá śiódmego dźiełá ſwego / które ucżynił ; y odpocżął w dźień śiódmy od wƺelkiego dźiełá ſwego / które ucżynił.
-Y błogoſłáwił Bóg dniowi śiódmemu / y poświęćił go ; iż weń odpocżął od wƺelkiego dźiełá ſwego / które był ſtworzył Bóg / áby ucżynione było.
-Teć ſą zrodzeniá niebioſ / y źiemi / gdy były ſtworzone / dniá / którego ucżynił Pán Bóg źiemię y niebo.
-Wƺelką różdżkę polną / przedtem niż byłá ná źiemi ; y wƺelkie źiele polne / pierwej niż weƺło ; ábowiem nie ſpuśćił jeƺcże był dżdżu Pán Bóg ná źiemię ; y cżłowieká nie było / któryby ſpráwowáł źiemię.
-Ale párá wychodźiłá z źiemi / która odwilżáłá wƺyſtek wierzch źiemi.
-Stworzył tedy Pán Bóg cżłowieká z prochu źiemi / y nátchnął w oblicże jego dech żywotá. Y ſtáł śię cżłowiek duƺą żywiącą.
-Náſádźił też był Pán Bóg ſád w Eden / ná wſchód ſłońcá / y poſtáwił tám cżłowieká / którego był ſtworzył.
-Y wywiódł Pán Bóg z źiemi wƺelkie drzewo wdźięcżne ná wejrzeniu / y ſmácżne ku jedzeniu ; y drzewo żywotá w pośrodku ſádu ; y drzewo wiádomośći dobrego y złego.
-A rzeká wychodźiłá z Eden dla odwilżeniá ſádu ; y ſtámtąd dźieliłá śię ná cżtery główne rzeki ;
-Imię jedney Fyſon ; tá okrążá wƺyſtkę źiemię Hewilá / gdźie śię rodźi złoto.
-A złoto źiemi oney jeſt wyborne. Támże jeſt Bdellion / y kámień Onychyn.
-A imię rzeki drugiej Gihon ; tá okrążá wƺyſtkę źiemię Murzyńſką.
-Imię záś rzeki trzećiej Chydekel / tá płynie ná wſchód ſłońcá ku Aſyryi. A rzeká cżwártá jeſt Eufráteſ.
-Wźiął tedy Pán Bóg cżłowieká / y poſtáwił go w ſádźie Eden / áby go ſpráwowáł / y áby go ſtrzegł.
-Tedy rozkázáł Pán Bóg cżłowiekowi / mówiąc : Z káżdego drzewá ſádu jeść będźieƺ.
-Ale z drzewá wiádomośći dobrego y złego / jeść z niego nie będźieƺ ; ábowiem dniá / którego jeść będźieƺ z niego / śmierćią umrzeƺ.
-Rzekł też Pán Bóg : Nie dobrze być cżłowiekowi ſámemu ; ucżynię mu pomoc / któráby byłá przy nim.
-A gdy ſtworzył Pán Bóg z źiemi wƺelki zwierz polny / y wƺelkie ptáſtwo niebieſkie / tedy je przywiódł do Adámá / áby obácżył / jákoby je názwáć miał ; á jákoby názwáł Adám káżdą duƺę żywiącą / ták áby było imię jey.
-Tedy dáł Adám imioná wƺyſtkiemu bydłu / y ptáſtwu niebieſkiemu / y wƺelkiemu zwierzowi polnemu. Lecż Adámowi nie byłá ználeźioná pomoc / któráby przy nim byłá.
-Tedy przypuśćił Pán Bóg twárdy ſen ná Adámá / y záſnął ; y wyjął jedno żebro jego / y nápełnił ćiáłem miáſto niego.
-Y zbudowáł Pán Bóg z żebrá onego / które wyjął z Adámá / niewiáſtę / y przywiódł ją do Adámá.
-Y rzekł Adám : Toć teraz jeſt kość z kośći moich / y ćiáło z ćiáłá mego ; dla tegoż będźie názwáná mężátką / bo oná z mężá wźiętá jeſt.
-Przetoż opuśći cżłowiek ojcá ſwego y mátkę ſwoję / á przyłącży śię do żony ſwojey / y będą jednem ćiáłem.
-A byli oboje nádzy / Adám y żoná jego ; á nie wſtydźili śię.
+Dokońcżone ſą tedy Niebioſá y źiemiá / y wƺyſtko woiſko ich.
+Y dokońcżył Bóg dniá śiódmego dźiełá ſwego które ucżynił : y odpocżynął w dźień śiódmy / od wƺelkiego dźiełá ſwego / które ucżynił.
+Y błogoſłáwił Bóg dniowi śiódmemu / y poświęćił go : yż weń odpocżynął od wƺelkiego dźiełá ſwego / które był ſtworzył Bóg / áby ucżynione było.
+Teć <i>ſą</i> zrodzenia Niebios y Źiemie gdy były ſtworzone dniá w który ucżynił PAN Bóg Źiemię y Niebo.
+Wƺelką różdżkę polną przed tym niż byłá ná Źiemi : y wƺelkie źiele polne / pierwey niż weƺło : Abowiem nie ſpuśćił <i>jeƺcże był</i> dżdżu PAN Bóg ná źiemię : Y cżłowieká nie było któryby ſpráwował źiemię.
+Ale párá wychodźiłá z źiemie / która odwilżáłá wƺyſtek wierzch Źiemie.
+Stworzył tedy PAN Bóg cżłowieká z prochu źiemie / y nátchnął w oblicże jego dech żywotá : Y ſtał śię cżłowiek duƺą żywiącą.
+Náſádźił też był PAN Bóg ſad w Eden / ná wſchód ſłońcá y poſtáwił tám cżłowieká którego był ſtworzył.
+Y wywiódł PAN Bóg z źiemie wƺelkie drzewo wdźięcżne ná wejrzeniu. Y ſmáczne ku jedzeniu : Y drzewo żywotá wpośrzodku ſádu. Y drzewo wiádomośći dobrego y złego.
+A Rzeká wychodźiłá z Eden dla odwilżeniá Sádu : y z támtąd dźieliłá śię / ná cżtery główne <i>rzeki</i>.
+Imię jedney Fiſon / tá okrąża wƺyſtkę źiemię Hewilá : gdźie <i>śię rodźi</i> złoto.
+A złoto źiemie oney <i>jeſt</i> wyborne : Támże jeſt Bdellion / y kámień Onychin :
+A imię Rzeki drugiey Gihon : Tá okrąża wƺyſtkę źiemię Murzyńſką.
+Imię záś Rzeki trzećiey Chidekel / tá płynie ná wſchód ſłońcá ku Aſſyryiey. A Rzeká cżwarta jeſt Eufrátes.
+Wźiął tedy PAN Bóg cżłowieká / y poſtáwił go w ſádźie Eden / áby go ſpráwował / y áby go ſtrzegł.
+Tedy rozkazał PAN Bóg cżłowiekowi / mówiąc / Z káżdego drzewá ſádu jeść będźieƺ.
+Ale z drzewá wiádomośći dobrego y złego / jeść z niego nie będźieƺ : ábowiem dniá którego jeść będźieƺ z niego / śmierćią umrzeƺ.
+Rzekł też PAN Bóg / Nie dobrze być cżłowiekowi ſámemu / ucżynię mu pomoc / któraby <i>byłá</i> przynim.
+A <i>gdy</i> ſtworzył PAN Bóg z źiemie wƺelki zwierz polny / y wƺelkie ptáſtwo niebieſkie / tedy <i>je</i> przywiódł do Adámá / áby obacżył / Jákoby je názwáć miał : á jákoby názwał Adam káżdą duƺę żywiącą <i>ták</i> áby było Imię jey.
+Tedy dał Adam imioná wƺyſtkiemu bydłu / y ptáſtwu Niebieſkiemu / y wƺelkiemu zwierzowi polnemu. Lecż Adámowi niebyłá ználeźioná pomoc / któraby przy nim byłá.
+Tedy przypuśćił PAN Bóg twárdy ſen ná Adámá / y záſnął : y wyjął jedno żebro jego / y nápełnił ćiáłem miáſto niego.
+Y zbudował PAN Bóg z żebrá onego które wyjął z Adámá / Niewiáſtę / y przywiódł ją do Adámá.
+Y rzekł Adam / Toć teraz <i>jeſt</i> kość z kośći mojich / y ćiáło z ćiáłá mego : dla tegoż będźie názwáná Mężátką / bo oná z mężá wźiętá jeſt.
+Przetoż opuśći cżłowiek Oicá ſwego y Mátkę ſwoję / á przyłącży śię do żony ſwojey / y będą jednym ćiáłem.
+A byli oboje nádzy / Adam y żoná jego : á nie wſtydźili śię.


### PR DESCRIPTION
"Pan" zamieniono na "PAN" na podstawie 1660 oraz późniejszych tekstów z 1632. Drobne korekty uzgodniono z 1660.