### PR TITLE
1 Moj. 3.

### DIFF
--- a/1632/01-gen/03.txt
+++ b/1632/01-gen/03.txt
@@ -1,24 +1,24 @@
-A wąż był chytrzejƺy nád wƺyſtkie zwierzętá polne / które był ucżynił Pán Bóg ; ten rzekł do niewiáſty : Tákże to / że wám Bóg rzekł : Nie będźiećie jedli z káżdego drzewá ſádu tego?
-Y rzekłá niewiáſtá do wężá : Z owocu drzewá ſádu tego pożywámy ;
-Ale z owocu drzewá / które jeſt w pośród ſádu / rzekł Bóg : Nie będźiećie jedli z niego / áni śię go dotykáć będźiećie / byśćie ſnáć nie pomárli.
-Y rzekł wąż do niewiáſty : Żádnym ſpoſobem śmierćią nie pomrzećie ;
-Ale wie Bóg / że któregokolwiek dniá z niego jeść będźiećie / otworzą śię ocży wáƺe ; á będźiećie jáko bogowie / znájący dobre y złe.
-Widząc tedy niewiáſtá / iż dobre było drzewo ku jedzeniu ; á iż było wdźięcżne ná wejrzeniu / á pożądliwe drzewo dla nábyćiá umiejętnośći / wźięłá z owocu jego / y jádłá ; dáłá też y mężowi ſwemu / który z nią był ; y on też jádł.
-Zátem otworzyły śię ocży obojgá / y poználi / że byli nágimi ; y ſpletli liśćie figowe / á pocżynili ſobie záſłony.
-A wtem uſłyƺeli głoſ Páná Bogá chodzącego po ſádźie z wiátrem dniowym ; y ſkrył śię Adám / y żoná jego od oblicżá Páná Bogá między drzewá ſádu.
-Y záwołáł Pán Bóg Adámá / y rzekł mu : Gdźieżeś?
-Który odpowiedźiáł : Głoſ twój uſłyƺáłem w ſádźie / y zlękłem śię dla tego / żem nági / y ſkryłem śię.
-Y rzekł Bóg : Któżći pokázáł / żeś jeſt nágim? izáliś nie jádł z drzewá onego / z któregom zákázáł tobie / ábyś nie jádł?
-Tedy rzekł Adám : Niewiáſtá / którąś mi dáł / áby byłá zemną / oná mi dáłá z tego drzewá / y jádłem.
-Y rzekł Pán Bóg do niewiáſty : Cóżeś to ucżyniłá? y rzekłá niewiáſtá : Wąż mię zwiódł / y jádłám.
-Tedy rzekł Pán Bóg do wężá : Iżeś to ucżynił / przeklętym będźieƺ nád wƺyſtkie zwierzętá / y nád wƺyſtkie beſtyje polne ; ná brzuchu twoim cżołgáć śię będźieƺ / á proch żreć będźieƺ po wƺyſtkie dni żywotá twego.
-Nieprzyjáźń też położę między tobą y między niewiáſtą / y między náśieniem twojim / y między náśieniem jey ; to potrze tobie głowę / á ty mu potrzeƺ piętę.
-A do niewiáſty rzekł : Obfićie rozmnożę boleśći twoje / y pocżęćiá twoje ; w boleśći rodźić będźieƺ dźieći / á wolá twá poddáná będźie mężowi twemu / á on nád tobą pánowáć będźie.
-Záś rzekł do Adámá : Iżeś uſłucháł głoſu żony twojey / á jádłeś z drzewá tego / o którememći przykázáł / mówiąc : Nie będźieƺ jádł z niego ; przeklętá będźie źiemiá dla ćiebie / w prácy z niej pożywáć będźieƺ po wƺyſtkie dni żywotá twego.
-A oná ćiernie y oſet rodźić będźie tobie ; y będźieƺ pożywáł źielá polnego.
-W poćie oblicżá twego będźieƺ pożywáł chlebá / áż śię náwróćiƺ do źiemi / gdyżeś z niej wźięty ; boś proch / y w proch śię obróćiƺ.
-Y názwáł Adám imię żony ſwej Ewá / iż oná byłá mátką wƺyſtkich żywiących.
-Y ucżynił Pán Bóg Adámowi / y żonie jego odźienie ſkórzáne / y oblókł je.
-Tedy rzekł Pán Bóg : Oto Adám ſtáł śię jáko jeden z nas / wiedzący dobre y złe ; teraz tedy wyżeńmy go / by ſnáć nie śćiągnął ręki ſwej / y nie wźiął z drzewá żywotá / y nie jádł / y żyłby ná wieki.
-Y wypuśćił go Pán Bóg z ſádu Eden / ku ſpráwowániu źiemi / z którey był wźięty.
-A ták wygnáł cżłowieká ; y poſtáwił ná wſchód ſłońcá ſádu Eden Cheruby / y miecż płomieniſty y obrotny ku ſtrzeżeniu drogi do drzewá żywotá.
+A wąż był chytrzejƺy nád wƺyſtkie zwierzętá polne które był ucżynił PAN Bóg : Ten rzekł do niewiáſty : tákże to / że wam Bóg rzekł? Nie będźiećie jedli z káżdego drzewa ſádu <i>tego</i>?
+Y rzekłá Niewiáſtá do wężá / Z owocu drzewá ſádu <i>tego</i> pożywamy.
+Ale z owocu drzewá które jeſt w pośrzód ſádu / rzekł Bóg : Niebędźiećie jedli z niego / áni śię go dotykáć będźiećie / byśćie ſnadź nie pomárli.
+Y rzekł wąż do Niewiáſty : żadnym ſpoſobem śmierćią nie pomrzećie :
+Ale wie Bóg / że któregokolwiek dniá z niego jeść będźiećie / otworzą śię ocży wáƺe : á będźiećie jáko Bogowie / znájący dobre y złe.
+Widząc tedy Niewiáſtá / yż dobre <i>było</i> drzewo ku jedzeniu : á yż było wdźięczne ná wejrzeniu / á pożądliwe drzewo dla <i>nábyćia</i> umiejętnośći / wźięłá z owocu jego / y jádłá : dałá też y mężowi ſwemu który znią był / y on też jadł.
+Zátym otworzyły śię ocży oboigá : y poználi że byli nágimi : y zpletli liśćie figowe / á pocżynili ſobie zaſłony.
+A <i>wtym</i> uſłyƺeli głos PANA Bogá chodzącego poſádu z wiátrem dniowym : y ſkrył śię Adam y żoná jego od oblicża PANá Bogá miedzy drzewá ſádu.
+Y záwołał PAN Bóg Adámá / y rzekł mu / Gdźieżeś?
+Który odpowiedźiał / Głos twój uſłyƺałem w ſádźie / y zlękłem śię dla tego żem nági / y ſkryłem śię.
+Y rzekł <i>Bóg</i> : któżći pokazał żeś <i>jeſt</i> nágim? izaliś nie jadł z drzewá onego z któregom zákazał tobie / ábyś nie jadł?
+Tedy rzekł Adam / Niewiáſtá którąś mi dał <i>áby byłá</i> zemną / oná mi dáłá z tego drzewá / y jadłem :
+Y rzekł PAN Bóg do Niewiáſty : Cóżeś to ucżyniłá? y rzekłá Niewiáſtá : wąż mię zwiódł / y jádłám.
+Tedy rzekł PAN Bóg do wężá yżeś to ucżynił / przeklętym będźieƺ nád wƺyſtkie zwierzętá / y nád wƺyſtkie beſtye polne : ná brzuchu twojim ćżołgáć śię będźieƺ : á proch żrzeć będźieƺ / po wƺyſtkie dni żywotá twego.
+Nieprzyjaźń też położę miedzy tobą y miedzy niewiáſtą : y miedzy naśieniem twojem / y miedzy naśieniem jey : To potrze tobie głowę / á ty mu potrzeƺ piętę.
+A do Niewiáſty rzekł : Obfićie rozmnożę boleśći twoje / y pocżęćia twoje : w boleśći rodźić będźieƺ dźieći / A wola twa poddána będźie mężowi twemu / á on nád tobą pánowáć będźie.
+Zaś rzekł do Adámá : Yżeś uſłuchał głoſu żony twojey / á jadłeś z drzewá tego / októrymemći przykazał / mówiąc / Nie będźieƺ jadł z niego : Przeklęta <i>będźie</i> źiemiá dla ćiebie / w pracy z niey pożywáć będźieƺ po wƺyſtkie dni żywotá twego.
+A <i>oná</i> ćiernie y oſet rodźić będźie tobie : y będźieƺ pożywał źiela polnego.
+W poćie oblicza twego będźieƺ pożywał chlebá : áż śię náwróćiƺ do źiemie / gdyżeś z niey wźięty : boś proch / y w proch śię obróćiƺ.
+Y názwał Adam imię żony ſwey Ewá / iż oná byłá Mátką wƺyſtkich żywiących.
+Y ucżynił PAN Bóg Adámowi y żenie jego odzienie ſkórzáne : y oblókł je.
+Tedy rzekł PAN Bóg : Oto Adam ſtał śię jáko jeden znas wiedzący dobre y złe : Teraz tedy <i>wyżeńmy go,</i> by ſnadź nie zćiągnął ręki ſwey / y niewźiął z drzewá żywotá / y niejadł / y żyłby ná wieki.
+Y wypuśćił go PAN Bóg z ſádu Eden ku ſpráwowániu źiemie z którey był wźięty.
+A <i>ták</i> wygnał cżłowieká : y poſtáwił ná wſchód ſłońcá ſádu Eden Cheruby / y miecż płomieniſty y obrotny ku ſtrzeżeniu drogi <i>do</i> drzewá żywotá.


### PR DESCRIPTION
"Pan" zamieniono na "PAN" na podstawie 1660 oraz późniejszych tekstów z 1632. Być może należy zastosować "PAn"? Jednakże 1660 czasem używa "PAN", a czasem "PAn". Już na podstawie 3 pierwszych rozdziałów, brak jest spójności między pisownią tego słowa w NT i ST 1632. Podobnie z łącznością wyrazów oraz stosowaniem "z" i "ż"...