### PR TITLE
1 Moj. 4.

### DIFF
--- a/1632/01-gen/04.txt
+++ b/1632/01-gen/04.txt
@@ -1,26 +1,26 @@
-Potem Adám poznał Ewę / żonę ſwoję / która pocżęłá y porodźiłá Káiná / y rzekłá : Otrzymáłám mężá od Páná.
-Y porodźiłá záśię brátá jego Ablá ; y był Abel páſterzem owiec / á Káin był rolnikiem.
-Y ſtáło śię po wielu dni / iż przynióſł Káin z owocu źiemi ofiárę Pánu.
-Tákże y Abel przynióſł z pierworodztw trzód ſwoich y z tłuſtośći ich ; y wejrzáł Pán ná Ablá y ná ofiárę jego.
-Ale ná Káiná y ná ofiárę jego nie wejrzáł ; y rozgniewáł śię Káin bárdzo / y ſpádłá twárz jego.
-Tedy rzekł Pán do Káiná : Przecżżeś śię zápálił gniewem á cżemu ſpádłá twárz twojá?
-Azáż / jeſli dobrze cżynić będźieƺ / nie będźieƺ wywyżƺon? á jeſli nie będźieƺ dobrze cżynił / we drzwiách grzech leży ; á do ćiebie chuć jego będźie / á ty nád nim pánowáć będźieƺ.
-Y rozmáwiáł Káin z Ablem brátem ſwoim. Y ſtáło śię / gdy byli ná polu / że powſtáł Káin ná Ablá brátá ſwego / y zábił go.
-Y rzekł Pán do Káiná : Gdźież jeſt Abel brát twój? który odpowiedźiáł : Niewiem ; izálim ja ſtróżem brátá mego?
-Y rzekł Bóg : Cóżeś ucżynił? Głoſ krwi brátá twego wołá do mnie z źiemi.
+Potym Adam poznał Ewę żonę ſwoję / która pocżęłá y porodźiła Káijná / y rzekłá : Otrzymáłám mężá od PAná.
+Y porodźiłá záśię brátá jego Ablá : y był Abel páſterzem owiec / á Káin był rolnikiem.
+Y ſtáło śię po wielu dni / iż przynióſł Káin z owocu źiemie ofiárę PAnu.
+Tákże y Abel przynióſł z pierworócdw trzód ſwojich y ztłuſtośći jch / y wejrzał PAn ná Ablá y ná ofiárę jego.
+Ale ná Káiná y ná ofiárę jego niewejrzał / y rozgniewał śię Káin bárzo / y ſpádłá twarz jego.
+Tedy rzekł PAn do Kájiná : Przecżżeś śię zápalił <i>gniewem</i>? á czemu ſpádłá twarz twojá?
+Azaż jeśli dobrze cżynić będźieƺ nie będźieƺ wywyżƺon? á jeśli nie będźieƺ dobrze czynił / we drzwiách grzech leży. A do ćiebie chuć jego <i>będźie,</i> á ty nád nim pánowáć będźieƺ.
+Y rozmawiał Káin z Ablem brátem ſwojm : Y ſtáło śię gdy byli ná polu / że powſtał Kajin ná Ablá brátá ſwego / y zábił go.
+Y rzekł PAn do Kajiná ; Gdźież jeſt Abel brát twój? który odpowiedźiał / Niewiem / Izalim ja ſtróżem brátá mego?
+Y rzekł <i>Bóg</i> : Cóżeś ucżynił? Głos krwie brátá twego woła do mnie z źiemie.
 Teraz tedy przeklętym będźieƺ ná źiemi / która otworzyłá uſtá ſwe / áby przyjęłá krew brátá twego z ręki twojey.
-Gdy będźieƺ ſpráwowáł źiemię / nie wydá więcey mocy ſwej tobie ; tułácżem / y biegunem będźieƺ ná źiemi.
-Tedy rzekł Káin do Páná : Więkƺá jeſt niepráwość mojá / niżby mi ją odpuśćić miáno.
-Oto mię dźiś wygániáƺ z oblicżá tey źiemi / á przed twárzą twoją ſkryję śię / y będę tułácżem / y biegunem ná źiemi ; y ſtánie śię / że ktokolwiek mię znájdźie / zábije mię.
-Y rzekł mu Pán : Záiſte / ktobykolwiek zábił Káiná / śiedmioráką odnieśie pomſtę. Y włożył Pán ná Káiná piątno / áby go nie zábijáł / ktobykolwiek ználázł.
-Tedy odƺedł Káin od oblicżá Páńſkiego / y mieƺkáł w źiemi Nod / ná wſchód ſłońcá od Eden.
-Y poznał Káin żonę ſwą / która pocżęłá / y porodźiłá Enochá ; y zbudowáł miáſto / y názwáł imię miáſtá tego imieniem ſyná ſwego / Enoch.
-Y urodźił śię Enochowi Irád / á Irád ſpłodźił Máwiáelá / á Máwiáel ſpłodźił Mátuſáelá / á Mátuſáel ſpłodźił Lámechá.
-Y pojął ſobie Lámech dwie żony ; imię jedney / Adá / á imię drugiej / Sellá.
-Tedy urodźiłá Adá Jábálá / który był ojcem mieƺkájących w námiećiech / y páſterzów.
-A imię brátá jego było Jubál / który był ojcem wƺyſtkich grájących ná hárfie / y ná muzyckiem nácżyniu.
-Sellá też urodźiłá Tubálkáiná / rzemieślniká wƺelkiej roboty / od miedźi y od żelázá. A śioſtrá Tubálkáinowá byłá Noemá.
-Tedy rzekł Lámech żonom ſwym / Adźie y Selli : Słuchájćie głoſu mego / żony Lámechowe / poſłuchájćie ſłów moich ; zábiłbym ja mężá ná zránienie moje / y młodźieńcá ná śiność moję.
-Jeſlić śiedmkroć mśćić śię będą zá Káiná / tedyć zá Lámechá śiedmdźieśiąt y śiedm kroć.
-Y poznał jeƺcże Adám żonę ſwą / która urodźiłá ſyná / y názwáłá imię jego Set / mówiąc : Dáł mi Bóg inne potomſtwo miáſto Ablá / którego zábił Káin.
-Setowi też urodźił śię ſyn / y názwáł imię jego Enoſ. Ná ten cżáſ pocżęto wzywáć imieniá Páńſkiego.
+Gdy będźieƺ ſpráwował źiemię / niewyda więcey mocy ſwey tobie / tułácżem y biegunem będźieƺ ná źiemi.
+Tedy rzekł Kajin do PAná. Więkƺa jeſt niepráwość mojá / niżby mi ją odpuśćić miano.
+Oto mię dźiś wyganiaƺ z oblicża tey źiemie / á przed twarzą twoją ſkryję śię / y będę tułaczem y biegunem ná źiemi : y ſtánie śię <i>że</i> ktokolwiek mię znajdźie / zábije mię.
+Y rzekł mu PAn / Zaiſte ktobykolwiek zábił Kaijná / śiedmioráką odnieśie pomſtę. Y włożył PAn ná Kaijná piątno / áby go nie zábijał / ktobykolwiek ználázł.
+Tedy odƺedł Káijn od oblicża PAńſkiego / y mieƺkał w źiemi Nod / ná wſchód ſłońcá od Eden.
+Y poznał Kájin żonę ſwą która pocżęłá y porodźiłá Enochá : y zbudował Miáſto / y názwał imię miáſtá tego / imieniem ſyná ſwego / Enoch.
+Y urodźił śię Enochowi Irád / á Irád ſpłodźił Máwiáelá / á Máwiáel ſpłodźił Mátuſáelá / á Mátuſáel zpłodźił Lámechá.
+Y pojął ſobie Lámech dwie żenie : imię jedney / Adá : á imię drugiey / Sellá.
+Tedy urodźiłá Ada Jábálá / który był Ojcem mieƺkájących w namjećiech / y páſterzów.
+A imię brátá jego <i>było</i> Jubál / który był Ojcem wƺyſtkich grájących ná Arfie y ná muzyckiem nacżyniu.
+Sellá też urodźiłá Tubálkájiná / rzemieśniká wƺelkiey roboty / od miedźi y od żelázá. A śioſtrá Tubálkájinowá / byłá Noemá.
+Tedy rzekł Lámech żonom ſwym Adźie y Selli / ſłuchajćie głoſu mego żony Lámechowe : Poſłuchajćie ſłów mojich / zábił bym ja mężá ná zránienie moje : y młodźieńcá / ná śiność moję.
+Jeślić śiedmkroć mśćić śię będą zá Kajiná / tedyć zá Lámechá śiedmdźieśiąt y śiedm kroć.
+Y poznał jeƺcze Adam żonę ſwą / która urodźiłá ſyná y názwáłá imię jego Set : <i>mówiąc</i> : Dał mi Bóg inne potomſtwo miáſto Ablá / którego zábił Kájn.
+Setowi też urodźił śię ſyn / y názwał imię jego Enos. Ná ten cżás poczęto wzywáć imienia PAńſkiego.


### PR DESCRIPTION
Różna pisownia: Kajin, Káin, Káijn, Káijná.
Pán.. => PAn..
Mimo wielu różnic z 1660, skorygowano wg 1632 (z założenia digitalizacja ma być 1632).