### PR TITLE
Jan.11.

### DIFF
--- a/1632/43-joh/11.txt
+++ b/1632/43-joh/11.txt
@@ -1,57 +1,57 @@
-A był niektóry chory Łázarz z Betániey / z miáſtecżká Máryey y Márty śioſtry jey.
+A był niektóry chory Łázarz z Betániey / z miáſtecżká Máryey y Marty śioſtry jey.
 ( A to byłá oná Márya / która pomázáłá PAná máśćią / y ućieráłá nogi jego włoſámi ſwojimi / którey brát Łázarz chorował. )
-Poſłáły tedy śioſtry do niego / mowiąc ; PAnie oto ten / którego miłujeƺ / choruje.
+Poſłáły tedy śioſtry do niego / mówiąc ; PAnie oto ten / którego miłujeƺ / choruje.
 A uſłyƺawƺy to JEzus / rzekł ; Tá chorobá nie jeſt ná śmierć / ále dla chwały Bożey / áby był uwielbiony Syn Boży przez nię.
-A JEzus umiłował Martę y śioſtrę jey / y Łázárzá.
+A JEzus miłował Martę / y śioſtrę jey / y Łázarzá.
 A gdy uſłyƺał iż choruje / tedy zoſtał przez dwá dni ná onymże miejſcu gdźie był.
-Lecż potym rzekł do ucżniów ſwojich ; Idźmy záśię do Judzkiey źiemie.
+Lecż potym rzekł do ucżniów ſwojich ; Idźmy záśię do Judſkiey źiemie.
 Rzekli mu ucżniowie ; Miſtrzu / teraz ƺukáli Żydowie / jákoby ćię ukámionowáli / á záśię tám idźieƺ?
-Odpowiedźiał JEzus ; Aza nie dwánaśćie jeſt godźin dniá? Jeśli kto chodźi we dnie nie obráźi śię ; bo widźi świátłość tego świátá.
-A jeśli kto chodźi w nocy / obráźi śię ; bo w nim świátłá niemáƺ.
-To powiedźiawƺy / potym rzekł do nich ; Łázarz przyjaćiel náƺ śpi / ále idę ábym go ze ſnu obudźił.
-Tedy rzekli ucżniowie jego ; PAnie / jeśliże śpi / będźie zdrów.
-Ale JEzus mowił o śmierći jego : lecż oni mniemáli / iż o záśnieniu ſnem mowił.
+Odpowiedźiał JEzus ; Aza nie dwánaśćie jeſt godźin dniá? Jeſli kto chodźi we dnie / nie obráźi śię ; bo widźi świátłość tego świátá.
+A jeſli kto chodźi w nocy / obráźi śię ; bo w nim świátłá niemáƺ.
+To powiedźiawƺy / potym rzekł do nich ; Łázarz przyjaćiel náƺ ſpi / ále idę ábym go ze ſnu obudźił.
+Tedy rzekli ucżniowie jego ; PAnie / jeſliże ſpi / będźie zdrów.
+Ale JEzus mówił o śmierći jego : lecż oni mniemáli / iż o záśnieniu ſnem mówił.
 Tedy im rzekł JEzus jáwnie ; Łázarz umárł.
-Y ráduję śię dla was ( ábyśćie wierzyli ) żem tám nie był : ále podźmy do niego.
-Rzekł zátym Tomaƺ / którego zwano Dydymus / ſpoł-ucżniom : Podźmy y my / ábyśmy z nim pomárli.
+Y ráduję śię dla was ( ábyśćie wierzyli ) żem tám nie był : ále pódźmy do niego.
+Rzekł zátym Tomaƺ / którego zwano Dydymus / ſpół-ucżniom : Pódźmy y my / ábyſmy z nim pomárli.
 Przyƺedƺy tedy JEzus / ználazł go już cżtery dni w grobie leżącego.
 ( A byłá Betánia bliſko Jeruzalem / jákoby ná piętnaśćie ſtájan. )
 A przyƺło było wiele Żydów do Marty y Máryey áby je ćieƺyli po bráćie ich.
 Martá tedy / gdy uſłyƺáłá że JEzus idźie / bieżáłá przećiwko niemu : ále Márya domá śiedźiáłá.
 Y rzekłá Martá do JEzuſá : PAnie / byś tu był / nie umárłby był brát mój.
-Ale y teraz wiem / że o cokolwiekbyś prośił Bogá / dáć to Bog.
+Ale y teraz wiem / że o cokolwiekbyś prośił Bogá / dać to Bóg.
 Rzekł jey JEzus ; Wſtánieć brát twój.
 Rzekłá mu Martá ; Wiem iż wſtánie przy zmartwychwſtániu / w on oſtátecżny dźień.
 Y rzekł jey JEzus ; Jam jeſt zmartwychwſtánie / y żywot : Kto w mię wierzy / choćby też umárł / żyć będźie.
 A wƺelki który żywie / á wierzy w mię / nie umrze ná wieki. Wierzyƺże temu?
 Rzekłá mu ; Y owƺem PAnie. Jam uwierzyłá żeś ty jeſt CHryſtus Syn Boży który miał przyść ná świát.
-A to rzekƺy ƺłá / y potájemnie záwołáłá Máryey śioſtry ſwojey / mowiąc : Jeſt tu Náucżyćiel / y woła ćię.
+A to rzekƺy ƺłá / y potájemnie záwołáłá Máryey śioſtry ſwojey / mówiąc : Jeſt tu Náucżyćiel / y woła ćię.
 Oná ſkoro uſłyƺáłá / wnet wſtáłá / y ƺłá do niego.
-( A JEzus jeƺcże był nie przyƺedł do miáſtecżká / ále był ná temże miejſcu / gdźie Martá byłá wyƺłá przećiwko niemu )
-Żydowie tedy / którzy z nią byli w domu / á ćieƺyli ją / ujrzawƺy Máryą / iż prędko wſtáła y wyƺłá / ƺli zá nią / mowiąc ; Idźie do grobu / áby tám płákáłá.
-Ale Márya gdy tám przyƺłá gdźie był JEzus / ujrzawƺy go / przypádłá do nog jego y rzekłá m ; PAnie / byś tu był / nie umárłby był brát mój.
-JEzus tedy / gdy ją ujrzał płácżącą / y Żydy którzy byli z nią przyƺli płácżące ; rozrzewnił śię w Duchu y záfráſował śię /
-Y rzekł : Gdźieśćie go położyli? Rzekli mu ; PAnie / podź / á oglądaj.
-Y zápłákał JEzus.
+( A JEzus jeƺcże był nie przyƺedł do miáſtecżká / ále był ná tymże miejſcu / gdźie Martá byłá wyƺłá przećiwko niemu. )
+Żydowie tedy którzy z nią byli w domu / á ćieƺyli ją / ujrzawƺy Máryą / iż prętko wſtáła y wyƺłá / ƺli zá nią / mówiąc ; Idźie do grobu / áby tám płákáłá.
+Ale Márya gdy tám przyƺłá gdźie był JEzus / ujrzawƺy go / przypádłá do nóg jego <i>y</i> rzekłá mu ; PAnie / byś tu był / nie umárłby był brát mój.
+JEzus tedy gdy ją ujrzał płácżącą / y Żydy którzy byli z nią przyƺli płácżące ; rozrzewnił śię w Duchu / y záfráſował śię.
+Y rzekł : Gdźieśćie go położyli? Rzekli mu ; PAnie / pódź / á oglądaj.
+<i>Y</i> zápłákał JEzus.
 Tedy rzekli Żydowie : Wej / jákoć go miłował?
-A niektórzy z nich mowili : Nie mogłże ten / który otworzył ocży ślepego / ucżynić / żeby ten był nie umárł?
+A niektórzy z nich mówili : Nie mógłże ten / który otworzył ocży ślepego / ucżynić / żeby ten był nie umárł?
 Ale JEzus rozrzewniwƺy śię ſam w ſobie / przyƺedł do grobu. A byłá jáſkinia ; á kámień był położony ná niey.
 Rzekł JEzus ; Odejmićie ten kámień. Rzekłá mu Martá śioſtrá onego umárłego : PAnie jużći cuchnie ; bo już jeſt cżtery dni w grobie.
-Powiedźiał jey JEzus ; Záżemći nie rzekł / Iż jeśli uwierzyƺ / oglądáƺ chwałę Bożą.
-Odjęli tedy kámień / gdźie był umárły położony. A JEzus podniozƺy ocży <i>ſwe</i> wzgorę / rzekł ; Ojcże! dźiękuję tobie żeś mię wyſłuchał.
+Powiedźiał jey JEzus ; Zażemći nie rzekł / Iż jeſli uwierzyƺ / oglądaƺ chwałę Bożą.
+Odjęli tedy kámień / gdźie był umárły położony. A JEzus podniózƺy ocży <i>ſwe</i> wzgórę / rzekł ; Ojcże / dźiękuję tobie żeś mię wyſłuchał.
 A Jamći wiedźiał / że mię záwżdy wyſłuchywaƺ ; álem to rzekł dla ludu w około ſtojącego / áby wierzyli żeś ty mnie poſłał.
 A to rzekƺy / záwołał głoſem wielkim ; Łázárzu / wynidź ſám!
-Y wyƺedł ten / który był umárł / májąc związáne ręce y nogi chuſtkámi / á twarz jego byłá chuſtką obwiązána. Rzekł im JEzus : Rozwiążćie go / á niechaj odejdźie.
+Y wyƺedł ten który był umárł / májąc związáne ręce y nogi chuſtkámi / á twarz jego byłá chuſtą obwiązána. Rzekł im JEzus : Rozwiążćie go / á niechaj odejdźie.
 Wiele tedy z Żydów / którzy byli przyƺli do Máryey / á widźieli to co ucżynił JEzus / uwierzyło weń.
 Niektórzy też z nich odeƺli do Fáryzeuƺów / y powiedźieli im / co ucżynił JEzus.
-Tedy śię zebráli Przedniejƺy Kápłáni y Fáryzeuƺowie w rádę / y mowili : Coż cżynimy? Abowiem ten cżłowiek wiele cudów cżyni?
-A jeśli go ták zániechamy / wƺyſcy weń uwierzą / y przydą Rzymiánie / á wezmą <i>ná</i> to miejſce náƺe / y lud.
-A jeden z nich Káifáƺ / będąc náwyżƺym Kápłanem onego roku / rzekł im : Wy nic nie wiećie ;
-Ani myślićie / iż nam jeſt pożytecżno / żeby jeden cżłowiek umárł zá lud : á żeby wƺyſtek ten narod nie zginął.
-A tegoć nie mowił ſam od śiebie / ále będąc Nawyżƺym Kápłanem roku onego / prorokował Iż JEzus miał umrzeć zá on narod.
-A nie tylko zá on narod / ále żeby też Syny Boże roſproƺone w jedno zgromádźił.
+Tedy śię zebráli Przedniejƺy Kápłani y Fáryzeuƺowie w rádę / y mówili : Cóż cżynimy? Abowiem ten cżłowiek wiele cudów cżyni?
+A jeſli go ták zániechamy / wƺyſcy weń uwierzą / y przydą Rzymiánie / á wezmą <i>nám</i> to miejſce náƺe / y lud.
+A jeden z nich Káifaƺ / będąc nawyżƺym Kápłanem onego roku / rzekł im : Wy nic nie wiećie ;
+Ani myślićie / iż nam jeſt pożytecżno / żeby jeden cżłowiek umárł zá lud : á żeby wƺyſtek ten naród nie zginął.
+A tegoć nie mówił ſam od śiebie / ále będąc Nawyżƺym Kápłanem roku onego / prorokował / Iż JEzus miał umrzeć zá on naród.
+A nie tylko zá on naród / ále żeby też Syny Boże roſproƺone w jedno zgromádźił.
 Od onego tedy dniá / rádźili śię ſpołem / áby go zábili.
-A JEzus już nie chodźił jáwnie między Żydámi / ále z támtąd odƺedł do krájiny / która jeſt bliſko puƺcży / do miáſtá które zowią Efrájim : y támże mieƺkał z ucżniámi ſwojimi.
-A byłá bliſko Wielkanoc Żydowſka : A wiele ich ƺło do Jeruzalem z oney krájiny przed Wielkanocą / áby śię ocżyśćili.
-Y ƺukáli JEzuſá : y mowili jedni do drugich / w Kośćiele ſtojąc : Co śię wáam zda że nie przyƺedł ná Święto?
-A Przedniejƺy Kápłani y Fáryzeuƺowie wydáli byli rozkazánie : Jeśliby śię kto dowiedźiał gdźieby był / żeby oznájmił / áby go pojimáli.
+A JEzus już nie chodźił jáwnie miedzy Żydámi / ále z támtąd odƺedł do krájiny / która jeſt bliſko puƺcży / do miáſtá które zowią Efrájim : y támże mieƺkał z ucżniámi ſwojimi.
+A byłá bliſko Wielkanoc Żydowſka : A wiele ich ƺło do Jeruzalem z oney krájiny przed Wielkąnocą / áby śię ocżyśćili.
+Y ƺukáli JEzuſá : y mówili jedni do drugich / w Kośćiele ſtojąc : Co śię wam zda że nie przyƺedł ná Święto?
+A Przedniejƺy Kápłani y Fáryzeuƺowie wydáli byli rozkazánie : Jeſliby śię kto dowiedźiał gdźieby był / żeby oznájmił / áby go pojimáli.


### PR DESCRIPTION
w.11 i 12: przy przyszłej rewizji ſpi -> śpi
w.48. wersja z 1660r. ma "nám" zamiast "ná"