### PR TITLE
1 Moj. 11.

### DIFF
--- a/1632/01-gen/11.txt
+++ b/1632/01-gen/11.txt
@@ -1,32 +1,32 @@
 A byłá wƺyſtká źiemiá jednego języká / y jedney mowy.
-Y ſtáło śię / gdy wyƺli od wſchodu ſłońcá / ználeſli równinę w źiemi Senáár / y mieƺkáli tám.
-Y rzekł jeden do drugiego : Nuże nácżyńmy cegły y wypálmy ją ogniem : y mieli cegłę miáſto kámieniá / á glinę iłowátą mieli miáſto wápná.
-Potem rzekli : Nużeż / zbudujmy ſobie miáſto y wieżą / którejby wierzch dośięgáł do niebá / á ucżyńmy ſobie imię ; byśmy śię ſnáć nie rozproƺyli po oblicżu wƺyſtkiej źiemi.
-Tedy Pán zſtąpił / áby oglądáł miáſto ono / y wieżą / którą budowáli ſynowie ludzcy.
-Y rzekł Pán : Oto lud jeden / y język jeden tych wƺyſtkich ; á toć jeſt zácżęćie dźiełá ich / á teraz nie zábroni im nikt wƺyſtkiego / co zámyślili ucżynić.
-Przetoż zſtąpmy / á pomieƺájmy tám język ich / áby jeden drugiego języká nie zrozumiáł.
-A ták rozproƺył je Pán ſtámtąd po oblicżu wƺyſtkiej źiemi ; y przeſtáli budowáć miáſtá onego.
-Przetoż názwáł imię jego Bábel ; iż tám pomieƺáł Pán język wƺyſtkiej źiemi ; y ſtámtąd rozproƺył je Pán po oblicżu wƺyſtkiej źiemi.
-Teć ſą rodzáje Semowe : Sem gdy miał ſto lát / ſpłodźił Arfáchſádá we dwá látá po potopie.
-Y żył Sem po ſpłodzeniu Arfáchſádá pięć ſet lát / y ſpłodźił ſyny y córki.
-Arfáchſád też żył trzydźieśći y pięć lát / y ſpłodźił Selechá.
-Y żył Arfáchſád po ſpłodzeniu Selechá cżtery ſtá lát / y trzy látá / y ſpłodźił ſyny y córki.
-Selech záś żył trzydźieśći lát / y ſpłodźił Heberá.
-Y żył Selech po ſpłodzeniu Heberá cżtery ſtá lát / y trzy látá / y ſpłodźił ſyny y córki.
-Y żył Heber trzydźieśći lát y cżtery / y ſpłodźił Pelegá.
-Żył też Heber po ſpłodzeniu Pelegá / cżtery ſtá lát / y trzydźieśći lát / y ſpłodźił ſyny y córki.
-Żył też Peleg trzydźieśći lát / y ſpłodźił Rehu.
-Y żył Peleg po ſpłodzeniu Rehu dwieśćie lát / y dźiewięć lát / y ſpłodźił ſyny y córki.
-Tákże Rehu żył trzydźieśći lát / y dwá / y ſpłodźił Sárugá.
-Y żył Rehu po ſpłodzeniu Sárugá dwieśćie lát / y śiedm lát / y ſpłodźił ſyny y córki.
-Sárug záś żył trzydźieśći lát / y ſpłodźił Náchorá.
-Y żył Sárug po ſpłodzeniu Náchorá dwieśćie lát / y ſpłodźił ſyny y córki.
-Tákże Náchor żył dwádźieśćiá y dźiewięć lát / y ſpłodźił Tárego.
-Y żył Náchor po ſpłodzeniu Tárego ſto lát y dźiewiętnáśćie lát / y ſpłodźił ſyny y córki.
-Y żył Táre śiedmdźieśiąt lát / y ſpłodźił Abrámá / Náchorá y Háráná.
-A teć ſą rodzáje Tárego : Táre ſpłodźił Abrámá / Náchorá y Háráná. Hárán záś ſpłodźił Lotá.
-Y umárł Hárán przed oblicżem Tárego ojcá ſwego / w źiemi národzeniá ſwego / w Ur Cháldejſkiem.
-Y pojęli Abrám y Náchor ſobie żony : imię żony Abrámowej było Sáráj / á imię żony Náchorowej Melchá / córká Háráná / ojcá Melchy / y ojcá Jeſchy.
-A byłá Sáráj niepłodná / y nie miáłá dźiátek.
-Wźiął tedy Táre Abrámá ſyná ſwego / y Lotá ſyná Háránowego / wnuká ſwego / y Sáráj niewiáſtę ſwoję / żonę Abrámá ſyná ſwego ; y wyƺli ſpołu z Ur Cháldejſkiego / áby ƺli do źiemi Chánánejſkiej ; á przyƺli áż do Háránu / y mieƺkáli tám.
-Y było dni Tárego dwieśćie lát / y pięć lát ; y umárł Táre w Háránie.
+Y ſtáło śię / gdy wyƺli od wſchodu <i>słońcá</i> ználeźli równinę w źiemi Senáár / y mieƺkáli tám.
+Y rzekł jeden do drugiego : Nuże náczyńmy cegły / y wypalmy ją ogniem : y mieli cegłę miáſto kámienia / á glinę iłowátą mieli miáſto wapná.
+Potym rzekli / Nużeƺ / zbudujmy ſobie miáſto / y wieżą / któreyby wierzch <i>dośięgał</i> do niebá / á ucżyńmy ſobie imię / byſmy śię ſnadź nie rozproƺyli po oblicżu wƺyſtkiey źiemie.
+Tedy PAn zſtąpił áby oglądał miáſto ono / y wieżą którą budowáli ſynowie ludzcy.
+Y rzekł PAn / Oto lud jeden y język jeden tych wƺyſtkich : á toć <i>jeſt</i> záczęćie dźiełá ich / á teraz niezábroni im nikt wƺyſtkiego co zámyślili uczynić.
+Przetoż z ſtąpmy á pomieƺajmy tám język ich / áby jeden drugiego języká niezrozumiał.
+A ták rozproƺył je PAn z támtąd po obliczu wƺyſtkiey źiemie : y przeſtáli budowáć / miáſtá onego.
+Przetoż názwał imię jego Babel : iż tám pomieƺał PAn język wƺyſtkiey źiemie : y z támtąd rozproƺył je PAn po obliczu wƺyſtkiey źiemie.
+Teć <i>ſą</i> rodzáje Semowe : Sem gdy miał ſto lat zpłodźił Arfáchſádá / we dwie lećie po potopie.
+Y żył Sem po zpłodzeniu Arfáchſádá pięć ſet lat / y zpłodźił Syny y Córki.
+Arfáchſád też żył trzydźieśći y pięć lat / y zpłodźił Selechá.
+Y żył Arfáchſád po zpłodzeniu Selechá cztery ſtá lat / y trzy látá / y zpłodźił Syny y Córki.
+Selech záś żył trzydźieśći lat / y zpłodźił Heberá :
+Y żył Selech po zpłodzeniu Heberá / cztery ſtá lat y trzy látá / y zpłodźił Syny y Córki.
+Y żył Heber trzydźieśći lat y cztery y zpłodźił Pelego.
+Żył też Heber po zpłodzeniu Pelegá / cztery ſtá lat y trzydźieśći lat / y zpłodźił Syny y Córki.
+Żył też Peleg trzydźieśći lat y zpłodźił Rehu.
+Y żył Peleg po zpłodzeniu Rehu dwieśćie lat y dźiewięć lat / y zpłodźił Syny y Córki.
+Tákże Rehu żył trzydźieśći lat y dwie / y zpłodźił Sárugá.
+Y żył Rehu po zpłodzeniu Sárugá dwieśćie lat y śiedm lat / y zpłodźił Syny y Córki.
+Sárug záś żył trzydźieśći lat / y zpłodźił Náchorá.
+Y żył Sárug po zpłodzeniu Náchorá dwieśćie lat / y zpłodźił Syny y Córki.
+Tákże Náchor żył dwádźieśćiá y dźiewięć lat / y zpłodźił Tárego.
+Y żył Náchor po zpłodzeniu Tárego ſto lat y dźiewiętnaśćie lat / y zpłodźił Syny y Córki.
+Y żył Táre śiedmdźieśiąt lat / y zpłodźił Abrámá / Náchorá y Háráná.
+A teć ſą rodzáje Tárego / Táre zpłodźił Abrámá / Náchorá / y Háráná. Hárán záś zpłodźił Lotá.
+Y umárł Hárán przed obliczem Tárego Ojcá ſwego w źiemi národzenia ſwego / w Ur Cháldejſkim.
+Y pojęli Abrám y Náchor ſobie żony : imię żony Abrámowey <i>było</i> Sárái á imię żony Náchorowey Melchá / Córká Háráná / Ojcá Melchy / y Ojcá Jeſchy.
+A byłá Sárái niepłodna / <i>y</i> niemiáłá dźiatek :
+Wźiął tedy Táre Abrámá Syná ſwego / y Lotá ſyná Háránowego wnuká ſwego / y Sárái niewiaſtkę ſwoję / żonę Abrámá Syná ſwego : y wyƺli zpołu z Ur Cháldejſkiego / áby ƺli do źiemie Chánánejſkiej : á przyƺli áż do Háránu / y mieƺkáli tám.
+Y było dni Tárego dwieśćie lat y pięć lat / y umárł Táre w Háránie.


### PR DESCRIPTION
w. 12-15. 
1632 oryg. jest "Sále" jednak pozostawiono "Selech" (jak w 1660)
Jednak KJV => "Salah" (warto rozważyć korektę).