### PR TITLE
Mat.28.

### DIFF
--- a/1632/40-mat/28.txt
+++ b/1632/40-mat/28.txt
@@ -1,20 +1,20 @@
-A gdy śię końcżył ſábát / y już świtáło ná pierwƺy dźień onego tygodniá / przyƺłá Máryjá Mágdálená y drugá Máryjá / áby grób oglądáły.
-A oto ſtáło śię wielkie trzęśienie źiemi ; ábowiem Anioł Páńſki zſtąpiwƺy z niebá / przyſtąpił y odwálił kámień ode drzwi / y uśiádł ná nim.
-A było wejrzenie jego jáko błyſkáwicá / á ƺátá jego biáłá jáko śnieg.
-A ći / którzy ſtrzegli grobu / drżeli / bojąc śię go / y ſtáli śię jáko umárli.
-Ale Anioł odpowiádájąc / rzekł do niewiáſt : Nie bójćie śię wy ; boć wiem / iż JEzuſá ukrzyżowánego ƺukáćie.
-Niemáƺći go tu ; ábowiem powſtáł / jáko powiedźiáł ; chodźćie / oglądájćie miejſce / gdźie leżáł Pán.
-A prędko idąc / powiedzćie ucżniom jego / że zmartwychwſtáł ; á oto uprzedzá was do Gálilei / tám go ujrzyćie ; otom wám powiedźiáł.
-Tedy wyƺedłƺy prędko od grobu z bojáźnią y z rádośćią wielką / bieżáły / áby to opowiedźiáły ucżniom jego.
-A gdy ƺły / áby to opowiedźiáły ucżniom jego / oto JEzuſ ſpotkáł śię z niemi / mówiąc : Bądźćie pozdrowione. A one przyſtąpiwƺy / uchwyćiły śię nóg jego y pokłoniły mu śię.
-Tedy im rzekł JEzuſ : Nie bójćie śię ; idźćie / opowiedzćie bráćiom moim / áby poƺli do Gálilei / á tám mię ujrzą.
-A gdy one poƺły / oto niektórzy z ſtráży przyƺedłƺy do miáſtá / oznájmili przedniejƺym kápłánom wƺyſtko / co śię ſtáło.
-Którzy zgromádźiwƺy śię z ſtárƺymi / y nárádźiwƺy śię / dáli niemáło pieniędzy żołnierzom /
-Mówiąc : Powiádájćie / iż ucżniowie jego w nocy przyƺedłƺy / ukrádli go / gdyśmy ſpáli.
-A jeſliby śię to do ſtároſty donioſło / my go námówimy á was bezpiecżnymi ucżynimy.
-A oni wźiąwƺy pieniądze / ucżynili / jáko ich náucżono. Y roznioſłá śię tá powieść między Żydy áż do dniá dźiśiejƺego.
-Lecż jedenáśćie ucżniów poƺli do Gálilei ná górę / gdźie im był náznácżył JEzuſ.
-Ale ujrzáwƺy go / pokłonili mu śię ; lecż niektórzy wątpili.
-Ale JEzuſ przyſtąpiwƺy / mówił do nich / á rzekł : Dáná mi jeſt wƺelká moc ná niebie y ná źiemi.
-Idąc tedy / náucżájćie wƺyſtkie národy / chrzcżąc je w imię Ojcá / y Syná / y Duchá Świętego ;
-Ucżąc je przeſtrzegáć wƺyſtkiego / com wám przykázáł. A oto Jám jeſt z wámi po wƺyſtkie dni / áż do ſkońcżeniá świátá. Amen.
+A gdy śię końcżył Sábbát / y już świtáło ná pierwƺy <i>dźień onego</i> tegodniá / przyƺłá Márya Mágdálená / y druga Márya / áby grób oglądáły.
+A oto ſtáło śię wielkie trzęśienie źiemie : Abowiem Anjoł PAńſki zſtąpiwƺy z niebá / przyſtąpił y odwálił kámień ode drzwi / y uśiadł ná nim.
+A było wejrzenie jego jáko błyſkáwicá ; á ƺátá jego biała / jáko śnieg.
+A ći którzy ſtrzegli <i>grobu,</i> drżeli / bojąc śię go ; y ſtáli śię jáko umárli.
+Ale Anjoł odpowiádájąc / rzekł do niewiaſt ; Nie bójćie śię wy / Boć wiem iż JEzuſá ukrzyżowánego ƺukaćie.
+Niemáƺći go tu : ábowiem powſtał jáko powiedźiał. Chodźćie oglądajćie miejſce gdźie leżał PAN.
+A prętko idąc / powiedzćie ucżniom jego / że zmartwychwſtał : á oto uprzedza was do Gálilejey ; tám go ujrzyćie. Otom wam powiedźiał.
+Tedy wyƺedƺy prętko od grobu z bojáźnią y z rádośćią wielką / bieżáły áby to opowiedźiáły ucżniom jego.
+A gdy ƺły áby to opowiedźiáły ucżniom jego / oto JEzus potkał śię z nimi / mówiąc : Bądźćie pozdrowione. A one przyſtąpiwƺy / uchwyćiły śię nóg jego / y pokłoniły mu śię.
+Tedy im rzekł JEzus : Nie bójćie śię ; idźćie / opowiedzćie bráći mojey / áby poƺli do Gálilejey ; á tám mię ujrzą.
+A gdy one poƺły / oto niektórzy z ſtraży przyƺedƺy do miáſtá / oznájmili Przedniejƺym kápłanom wƺyſtko co śię ſtáło.
+Którzy zgromádźiwƺy śię z Stárƺymi / y nárádźiwƺy śię / dáli niemáło pieniędzy żołnierzom /
+Mówiąc : Powiádajćie / iż ucżniowie jego w nocy przyƺedƺy / ukrádli go gdyſmy my ſpáli.
+A jeſliby śię to Stároſty donioſło / my go námówimy / á was beſpiecżnymi ucżyniemy.
+A oni wźiąwƺy pieniądze / ucżynili jáko ich náucżono. Y roznioſłá śię tá powieść miedzy Żydy / áż do dniá dźiśiejƺe°.
+Lecż jedenaśćie ucżniów poƺli do Gálilejey ná górę / gdźie im był náznácżył JEzus.
+A ujrzawƺy go / pokłonili mu śię : lecż niektórzy wątpili.
+Ale JEzus przyſtąpiwƺy mówił do nich / á rzekł : Dáná mi jeſt wƺelka moc ná niebie y ná źiemi.
+Idąc tedy náucżajćie wƺyſtkie narody / chrzcżąc je w Imię Ojcá y Syná y Duchá Świętego.
+Ucżąc je przeſtrzegáć wƺyſtkiego com wam przykazał. A oto jam jeſt z wámi po wƺyſtkie dni / áż do ſkońcżenia świátá / Amen.


### PR DESCRIPTION
w.4. 1660 ma na końcu kropkę zamiast ukośnika
w.9. "potkał" -> 1632 i 1660; a 1606 ma zabieżał im
w.15. 1660 ma "dźiśiejƺego", 1632 ma na końcu ° najpewniej ze względu na brak miejsca w wierszu.