### PR TITLE
1 Król.15,27.

### DIFF
--- a/1879/11-reg/15.txt
+++ b/1879/11-reg/15.txt
@@ -24,7 +24,7 @@ A inne wszystkie sprawy Azy, i wszystka moc jego, i cokolwiek czynił, i miasta,
 I zasnął Aza z ojcy swymi, a pochowany jest z nimi w mieście Dawida, ojca swego. A Jozafat, syn jego, królował miasto niego.
 Ale Nadab, syn Jeroboama, nastąpił na królestwo Izraelskie roku wtórego Azy, króla Judzkiego, i królował nad Izraelem dwa lata;
 I czynił złe przed oczyma Pańskiemi, chodząc drogami ojca swego, i w grzechach jego, któremi do grzechu przywodził Izraela.
-I zbuntował się przeciw niemu Baaza, syn Ahyjasza, z domu Isaschar; a poraził go Baaza u Giebbeton, które było Filistyńskie; bo Nadab ze wszystkim Izraelem obległ był Giebbeton.
+I zbuntował się przeciw niemu Baaza, syn Achyjasza, z domu Isaschar; a poraził go Baaza u Giebbeton, które było Filistyńskie; bo Nadab ze wszystkim Izraelem obległ był Giebbeton.
 I zabił go Baaza roku trzeciego Azy, króla Judzkiego, a sam królował miasto niego.
 I stało się, gdy począł królować, że wymordował wszystek dom Jeroboamowy; a nie zostawił żadnej duszy z narodu Jeroboamowego, aż je wytracił według słowa Pańskiego, które był opowiedział przez sługę swego Achyjasza Sylonitczyka;
 A to dla grzechów Jeroboamowych, który grzeszył, i który do grzechu przywiódł Izraelczyki, i dla przestępstwa, którem wzruszył ku gniewu Pana, Boga Izraelskiego.


### PR DESCRIPTION
błąd jest w druku, por. w.33 - jest tam również pisane przez "ch"