### PR TITLE
Mat.26.

### DIFF
--- a/1632/40-mat/26.txt
+++ b/1632/40-mat/26.txt
@@ -9,7 +9,7 @@ Co widząc ucżniowie jego / rozgniewáli śię / mówiąc : Y ná cóż tá utr
 Abowiem mogłá być tá máść drogo przedána / y mogło śię to dáć ubogim.
 Co gdy poznał JEzus / rzekł im : Przecż śię przykrzyćie tey niewieśćie? Dobry záprawdę ucżynek ucżyniłá przećiwko mnie.
 Abowiem ubogie záwƺe maćie z ſobą / ále mnie nie záwƺe mieć będźiećie.
-Bo oná wylawƺy tę máść ná ćiáło moje / ucżyniłá to / gotując mięAżku pogrzebowi.
+Bo oná wylawƺy tę máść ná ćiáło moje / ucżyniłá to / gotując mię ku pogrzebowi.
 Záprawdę powiádam wam : Gdźiekolwiek będźie kazána tá Ewángelia po wƺyſtkim świećie / y to będźie powiádano / co oná ucżyniłá / ná pámiątkę jey.
 Tedy odƺedƺy jeden ze dwunaśći / którego zwano Judaƺem Iƺkáryotem / do przedniejƺych Kápłanów /
 Rzekł im ; Co mi chcećie dáć / á ja go wam wydam? A oni mu odważyli trzydźieśći śrebrników.
@@ -21,7 +21,7 @@ A gdy był wiecżór / uśiadł <i>zá ſtołem</i> ze dwiemánaśćie.
 A gdy jedli / rzekł : Záprawdę powiádam wam / iż jeden z was wyda mię.
 Y záſmęćiwƺy śię bárzo / pocżęli mówić do niego káżdy z nich : Azażem ja jeſt PAnie?
 A on odpowiádájąc / rzekł ; Który macża ze mną rękę w miśie / ten mię wyda.
-Synći cżłowiecży idźie / jáko nápiſano o nim : ále biádá cżłowiekowi temu / przez którego Syn cżłowiecży wydány bywa! dobrze mu było / by śię był nie národźił ten cżłowiek.
+Synći cżłowiecży idźie / jáko nápiſano o nim : ále biádá cżłowiekowi temu / przez którego Syn cżłowiecży wydány bywa! dobrze <i>by</i> mu było / by śię był nie národźił ten cżłowiek.
 A odpowiádájąc Judaƺ / który go wydawał / rzekł ; Izalim ja jeſt Miſtrzu? Mówi mu ; Tyś powiedźiał.
 A gdy oni jedli / wźiąwƺy JEzus chleb / á pobłogoſłáwiwƺy / łamał / y dał ucżniom / y rzekł ; Bierzćie / jedzćie ; to jeſt ćiáło moje.
 A wźiąwƺy kielich / y podźiękowawƺy / dał im mówiąc ; Pijćie z tego wƺyſcy :
@@ -42,7 +42,7 @@ Cżujćież á módlćie śię / ábyśćie nie weƺli w pokuƺenie : Duchći je
 Záśię powtóre odƺedƺy / modlił śię / mówiąc ; Ojcże mój / Jeſli mię nie może ten kielich minąć / tylko ábym go pił / niech śię ſtánie wola twojá.
 A przyƺedƺy / ználazł je záśię ſpiące : ábowiem ocży ich były obćiążone.
 A zániechawƺy ich / znowu odƺedł ; y modlił śię potrzećie / też ſłowá mówiąc.
-Tedy przyƺedł do ucżniów ſwojich / y rzekł im ; Śpićież już / y odpocżywaćie : oto śię przybłyżyłá godźiná / á Syn cżłowiecży będźie wydány w ręce grzeƺników.
+Tedy przyƺedł do ucżniów ſwojich / y rzekł im ; Śpićież już / y odpocżywajćie : oto śię przybłyżyłá godźiná / á Syn cżłowiecży będźie wydány w ręce grzeƺników.
 Wſtańćie / pódźmy : oto śię przybliżył ten / który mię wydawa.
 A gdy on jeƺcże mówił / oto Judaƺ jeden ze dwunaśći przyƺedł á z nim wielka zgrájá / z miecżámi / y z kijmi od Przedniejƺych kápłanów / y Stárƺych ludu :
 Ale ten który go wydawał / dał im był znák / mówiąc : Któregokolwiek pocáłuję / tenći jeſt : jimajćież go.

--- a/1632/40-mat/26.txt
+++ b/1632/40-mat/26.txt
@@ -1,75 +1,75 @@
-Y ſtáło śię / gdy dokońcżył JEzus tych wƺyſtkich mów / rzekł do ucżniów ſwojich :
-Wiećie / iż po dwu dniách będźie wielkánoc á Syn cżłowiecży będźie wydány / áby był ukrzyżowány.
-Tedy śię zebráli przedniejśi kápłáni y náucżeni w Piśmie y ſtárśi ludu do dworu nájwyżƺego kápłáná / którego zwano Káifáƺ ;
-Y nárádzáli śię / jákoby JEzuſá zdrádą pojmáli y zábili ;
-Lecż mówili : Nie w święto / áby nie był rozruch miedzy ludem.
-A gdy JEzus był w Betániey / w domu Szymoná trędowátego /
-Przyſtąpiłá do niego niewiáſtá / májącá ſłoik álábáſtrowy máśći bárzo koƺtowney / y wyláłá ją ná głowę jego / gdy śiedźiał u ſtołu.
+Y ſtáło śię / gdy dokońcżył JEzus tych wƺyſtkich mów / rzekł do ucżniów ſwojich ;
+Wiećie iż po dwu dniách będźie Wielkanoc / á Syn cżłowiecży będźie wydány áby był ukrzyżowány.
+Tedy śię zebráli Przedniejƺy Kápłani / y Náucżeni w piśmie / y Stárƺy ludu do dworu Nawyżƺego Kápłaná / którego zwano Káifaƺ.
+Y náradzáli śię / jákoby JEzuſá zdrádą pojimáli / y zábili.
+Lecż mówili ; Nie w Święto : áby nie był rozruch miedzy ludem.
+A gdy JEzus był w Betániey w domu Symoná trędowátego :
+Przyſtąpiłá do niego niewiáſtá / májąca ſłojek álábáſtrowy máśći bárzo koƺtowney : y wylałá ją ná głowę jego / gdy śiedźiał u ſtołu.
 Co widząc ucżniowie jego / rozgniewáli śię / mówiąc : Y ná cóż tá utrátá?
-Abowiem mogłá być tá máść drogo ſprzedáná / y mogło śię to dáć ubogim.
-Co gdy poznał JEzus / rzekł im : Przecż śię przykrzyćie tey niewieśćie? Dobry zápráwdę ucżynek ucżyniłá przećiwko mnie.
-Abowiem ubogie záwƺe máćie z ſobą / ále mnie nie záwƺe mieć będźiećie.
-Bo oná wyláwƺy tę máść ná ćiáło moje / ucżyniłá to / gotując mię ku pogrzebowi.
-Zápráwdę powiádám wam : Gdźiekolwiek będźie kázáná tá Ewángielijá po wƺyſtkim świećie / y to będźie powiádáno / co oná ucżyniłá / ná pámiątkę jey.
-Tedy odƺedƺy jeden ze dwunáſtu / którego zwano Judáƺem Iƺkáryjotem / do przedniejƺych kápłanów /
-Rzekł im : Co mi chcećie dáć / á ja go wam wydám? A oni mu odwáżyli trzydźieśći ſrebrników.
-A odtąd ƺukał cżáſu ſpoſobnego / áby go wydał.
-A pierwƺego dniá przáśników przyſtąpili ucżniowie do JEzuſá / mówiąc mu : Gdźież chceƺ / żeć nágotujemy / ábyś jádł báránká?
-A on rzekł : Idźćie do miáſtá / do niektórego cżłowieká / á rzecżćie mu : Kázáłći náucżyćiel powiedźieć : Cżás mój bliſko jeſt / u ćiebie jeść będę báránká z ucżniámi moimi.
-Y ucżynili ucżniowie / jáko im rozkázał JEzus / y nágotowáli báránká.
-A gdy był wiecżór / uśiádł zá ſtołem ze dwunáſtomá.
-A gdy jedli / rzekł : Zápráwdę powiádám wam / iż jeden z was wydá mię.
-Y záſmućiwƺy śię bárzo / pocżęli mówić do niego káżdy z nich : Azáżem ja jeſt Pánie?
-A on odpowiádájąc / rzekł : Który mácżá zemną rękę w miśie / ten mię wydá.
-Synći cżłowiecży idźie / jáko nápiſano o nim ; ále biádá cżłowiekowi temu / przez którego Syn cżłowiecży wydány bywa! dobrzeby mu było / by śię był nie národźił ten cżłowiek.
-A odpowiádájąc Judáƺ / który go wydáwał / rzekł : Izálim ja jeſt / Miſtrzu? Mówi mu : Tyś powiedźiał.
-A gdy oni jedli / wźiąwƺy JEzus chleb / á pobłogoſłáwiwƺy łámał / y dał ucżniom y rzekł : Bierzćie / jedzćie / to jeſt ćiáło moje.
-A wźiąwƺy kielich y podźiękowáwƺy / dał im / mówiąc : Pijćie z tego wƺyſcy ;
-Abowiem to jeſt krew mojá nowego teſtámentu / która śię zá wielu wylewá ná odpuƺcżenie grzechów.
-Ale powiádám wam / iż nie będę pił odtąd z tego rodzáju winney máćicy / áż do dniá onego / gdy go będę pił z wámi nowy w króleſtwie Ojcá mego.
-Y záśpiewáwƺy pieśń / wyƺli ná górę oliwną.
-Tedy im rzekł JEzus : Wy wƺyſcy zgorƺyćie śię ze mnie tey nocy ; ábowiem nápiſano : Uderzę páſterzá / y będą rozproƺone owce trzody.
-Lecż gdy ja zmartwychwſtánę / poprzedzę was do Gálilei.
-A odpowiádájąc Piotr / rzekł mu : Choćby śię wƺyſcy zgorƺyli z ćiebie / ja śię nigdy nie zgorƺę.
-Rzekł mu JEzus : Zápráwdę powiádám ći / iż tey nocy / pierwej niż kur zápieje / trzykroć śię mnie záprzeƺ.
-Rzekł mu Piotr : Choćbym z tobą miał y umrzeć / nie záprę śię ćiebie. Tákże y wƺyſcy ucżniowie mówili.
-Tedy przyƺedł JEzus z nimi ná miejſce / które zwano Gietſemáne / y rzekł ucżniom : Siądźćież tu / áż odƺedƺy / będę śię tám modlił.
-A wźiąwƺy z ſobą Piotrá y dwu ſynów Zebedeuƺowych / pocżął śię ſmęćić y tęſknić.
-Tedy im rzekł JEzus : Smętná jeſt duƺá mojá áż do śmierći ; zoſtáńćież tu / á cżujćie ze mną.
-A poſtąpiwƺy trochę / pádł ná oblicże ſwoje / modląc śię y mówiąc : Ojcże mój / jeſli można / niech mię ten kielich minie ; á wƺákże nie jáko ja chcę / ále jáko ty.
-Tedy przyƺedł do ucżniów / y ználázł je śpiące / y rzekł Piotrowi : Tákżeśćie nie mogli przez jednę godźinę cżuć zemną?
-Cżujćież á módlćie śię / ábyśćie nie weƺli w pokuƺenie ; duchći jeſt ochotny / ále ćiáło mdłe.
-Záśię powtóre odƺedƺy / modlił śię / mówiąc : Ojcże mój / jeſli mię nie może ten kielich minąć / tylko ábym go pił / niech śię ſtánie wolá twojá.
-A przyƺedƺy / ználázł je záśię śpiące ; ábowiem ocży ich były obćiążone.
-A zániecháwƺy ich / znowu odƺedł y modlił śię po trzećie / też ſłowá mówiąc.
-Tedy przyƺedł do ucżniów ſwojich y rzekł im : Śpijćież już y odpocżywájćie ; oto śię przybliżyłá godźiná / á Syn cżłowiecży będźie wydány w ręce grzeƺników.
-Wſtáńćie / pójdźmy! oto śię przybliżył ten / który mię wydáje.
-A gdy on jeƺcże mówił / oto Judáƺ / jeden z dwunáſtu / przyƺedł / á z nim wielka zgrájá z miecżámi y z kijámi / od przedniejƺych kápłanów y ſtárƺych ludu ;
-Ale ten / który go wydáwał / dał im był znák / mówiąc : Któregokolwiek pocáłuję / tenći jeſt ; imájćież go.
-A wnet przyſtąpiwƺy do JEzuſá / rzekł : Bądź pozdrowiony / Miſtrzu! y pocáłował go.
-Ale mu rzekł JEzus : Przyjáćielu! ná coś przyƺedł? Tedy przyſtąpiwƺy / rzućili ręce ná JEzuſá y pojmáli go.
-A oto jeden z tych / którzy byli z JEzuſem / wyćiągnął rękę / y dobył miecżá ſwego / á uderzywƺy ſługę kápłáná nájwyżƺego / ućiął mu ucho.
-Tedy mu rzekł JEzus : Obróć miecż twój ná miejſce jego ; ábowiem wƺyſcy / którzy miecż biorą / od miecżá poginą.
-Azaż mniemáƺ / żebym nie mógł teraz prośić Ojcá mego / á ſtáwiłby mi więcey niż dwánaśćie wojſk Aniołów?
-Ale jákożby śię wypełniły Piſmá / które mówią / iż śię ták muśi ſtáć?
-Onejże godźiny mówił JEzus do oney zgrái : Wyƺliśćie jáko ná zbójcę z miecżámi y z kijmi / pojmáć mię ; ná káżdy dźień śiádáłem u was / ucżąc w kośćiele / á nie pojmáliśćie mię.
-Aleć śię to wƺyſtko ſtáło / áby śię wypełniły Piſmá prorockie. Tedy ucżniowie jego wƺyſcy opuśćiwƺy go / ućiekli.
-A oni pojmáwƺy JEzuſá / wiedli go do Káifáƺá / nájwyżƺego kápłáná / gdźie śię byli zebráli náucżeni w Piśmie y ſtárśi.
-Ale Piotr ƺedł zá nim z dáleká áż do dworu nájwyżƺego kápłáná ; á wƺedƺy tám / śiedźiał z ſługámi / áby ujrzał koniec.
-Ale przedniejśi kápłáni y ſtárśi / y wƺelká rádá ƺukáli fáłƺywego świádectwá przećiwko JEzuſowi / áby go ná śmierć wydáli.
-Ale nie ználeſli ; y choć wiele fáłƺywych świádków przychodźiło / przećię nie ználeſli. A ná oſtátek wyſtąpiwƺy dwáj fáłƺywi świádkowie /
-Rzekli : Ten mówił : Mogę rozwálić kośćiół Boży / á zá trzy dni zbudowáć go.
-A wſtáwƺy nájwyżƺy kápłán / rzekł mu : Nic nie odpowiádáƺ? Cóż to jeſt / co ći przećiwko tobie świádcżą?
-Lecż JEzus milcżał. A odpowiádájąc nájwyżƺy kápłán rzekł mu : Poprzyśięgám ćię przez Bogá żywego / ábyś nam powiedźiał / jeſliś ty jeſt CHryſtus / on Syn Boży?
-Rzekł mu JEzus : Tyś powiedźiał ; wƺákże powiádám wam : Odtąd ujrzyćie Syná cżłowiecżego śiedzącego ná práwicy mocy Bożey / y przychodzącego ná obłokách niebieſkich.
-Tedy nájwyżƺy kápłán rozdárł ƺáty ſwoje / mówiąc : Bluźnił! Cóż jeƺcże potrzebujemy świádków? Otośćie teraz ſłyƺeli bluźnierſtwo jego.
+Abowiem mogłá być tá máść drogo przedána / y mogło śię to dáć ubogim.
+Co gdy poznał JEzus / rzekł im : Przecż śię przykrzyćie tey niewieśćie? Dobry záprawdę ucżynek ucżyniłá przećiwko mnie.
+Abowiem ubogie záwƺe maćie z ſobą / ále mnie nie záwƺe mieć będźiećie.
+Bo oná wylawƺy tę máść ná ćiáło moje / ucżyniłá to / gotując mięAżku pogrzebowi.
+Záprawdę powiádam wam : Gdźiekolwiek będźie kazána tá Ewángelia po wƺyſtkim świećie / y to będźie powiádano / co oná ucżyniłá / ná pámiątkę jey.
+Tedy odƺedƺy jeden ze dwunaśći / którego zwano Judaƺem Iƺkáryotem / do przedniejƺych Kápłanów /
+Rzekł im ; Co mi chcećie dáć / á ja go wam wydam? A oni mu odważyli trzydźieśći śrebrników.
+A od tąd ƺukał cżáſu ſpoſobnego / áby go wydał.
+A pierwƺego dniá Przáſników / przyſtąpili ucżniowie do JEzuſá / mówiąc mu ; Gdźież chceƺ żeć nágotujemy / ábyś jadł Báránká?
+A on rzekł ; Idźćie do miáſtá / do niektórego <i>cżłowieká,</i> á rzecżćie mu ; Kazałći Náucżyćiel powiedźieć ; Cżás mój bliſko jeſt / u ćiebie jeść będę Báránká z ucżniámi mojimi.
+Y ucżynili ucżniowie jáko im rozkazał JEzus ; y nágotowáli Báránká.
+A gdy był wiecżór / uśiadł <i>zá ſtołem</i> ze dwiemánaśćie.
+A gdy jedli / rzekł : Záprawdę powiádam wam / iż jeden z was wyda mię.
+Y záſmęćiwƺy śię bárzo / pocżęli mówić do niego káżdy z nich : Azażem ja jeſt PAnie?
+A on odpowiádájąc / rzekł ; Który macża ze mną rękę w miśie / ten mię wyda.
+Synći cżłowiecży idźie / jáko nápiſano o nim : ále biádá cżłowiekowi temu / przez którego Syn cżłowiecży wydány bywa! dobrze mu było / by śię był nie národźił ten cżłowiek.
+A odpowiádájąc Judaƺ / który go wydawał / rzekł ; Izalim ja jeſt Miſtrzu? Mówi mu ; Tyś powiedźiał.
+A gdy oni jedli / wźiąwƺy JEzus chleb / á pobłogoſłáwiwƺy / łamał / y dał ucżniom / y rzekł ; Bierzćie / jedzćie ; to jeſt ćiáło moje.
+A wźiąwƺy kielich / y podźiękowawƺy / dał im mówiąc ; Pijćie z tego wƺyſcy :
+Abowiem to jeſt krew mojá Nowego Teſtámentu / która śię zá wielu wylewa ná odpuƺcżenie grzechów.
+Ale powiádam wam / iż nie będę pił od tąd z tego rodzáju winney máćice / áż do dniá onego / gdy go będę pił z wámi nowy w króleſtwie Ojcá mego.
+Y záśpiewawƺy pieśń / wyƺli ná górę Oliwną.
+Tedy im rzekł JEzus ; Wy wƺyſcy zgorƺyćie śię ze mnie tey nocy. Abowiem nápiſano ; Uderzę páſterzá / y będą roſproƺone owce trzody.
+Lecż gdy ja zmartwychwſtánę / poprzedzę was do Gálilejey.
+A odpowiádájąc Piotr / rzekł mu ; Choćby śię wƺyſcy zgorƺyli z ćiebie / ja śię nigdy nie zgorƺę.
+Rzekł mu JEzus ; Záprawdę powiádamći / iż tey nocy / pierwey niż kur zápieje / trzy kroć śię mnie záprzyƺ.
+Rzekł mu Piotr ; Choćbym z tobą miał y umrzeć / nie záprę śię ćiebie. Tákże y wƺyſcy ucżniowie mówili.
+Tedy przyƺedł JEzus z nimi ná miejſce które zwano Getſemáne / y rzekł ucżniom ; Śiedźćież tu / áż odƺedƺy / będę śię tám modlił.
+A wźiąwƺy z ſobą Piotrá / y dwu ſynów Zebedeuƺowych / pocżął śię ſmęćić y teſknić.
+Tedy im rzekł <i>JEzus</i> ; Smętna jeſt duƺá mojá áż do śmierći ; zoſtańćież tu / á cżujćie ze mną.
+A poſtąpiwƺy trochę / padł ná oblicże ſwoje / modląc śię / y mówiąc ; Ojcże mój / Jeſli można / niech mię ten kielich minie : á wƺákże / nie jáko ja chcę / ále jáko ty.
+Tedy przyƺedł do ucżniów / y ználazł je ſpiące / y rzekł Piotrowi ; Tákżeśćie nie mogli przez jednę godźinę cżuć ze mną?
+Cżujćież á módlćie śię / ábyśćie nie weƺli w pokuƺenie : Duchći jeſt ochotny / ále ćiáło mdłe.
+Záśię powtóre odƺedƺy / modlił śię / mówiąc ; Ojcże mój / Jeſli mię nie może ten kielich minąć / tylko ábym go pił / niech śię ſtánie wola twojá.
+A przyƺedƺy / ználazł je záśię ſpiące : ábowiem ocży ich były obćiążone.
+A zániechawƺy ich / znowu odƺedł ; y modlił śię potrzećie / też ſłowá mówiąc.
+Tedy przyƺedł do ucżniów ſwojich / y rzekł im ; Śpićież już / y odpocżywaćie : oto śię przybłyżyłá godźiná / á Syn cżłowiecży będźie wydány w ręce grzeƺników.
+Wſtańćie / pódźmy : oto śię przybliżył ten / który mię wydawa.
+A gdy on jeƺcże mówił / oto Judaƺ jeden ze dwunaśći przyƺedł á z nim wielka zgrájá / z miecżámi / y z kijmi od Przedniejƺych kápłanów / y Stárƺych ludu :
+Ale ten który go wydawał / dał im był znák / mówiąc : Któregokolwiek pocáłuję / tenći jeſt : jimajćież go.
+A wnet przyſtąpiwƺy do JEzuſá / rzekł ; Bądź pozdrowiony Miſtrzu : y pocáłował go.
+Ale mu rzekł JEzus : Przyjaćielu / ná coś przyƺedł? Tedy przyſtąpiwƺy / rzućili ręce ná JEzuſá / y pojimáli go.
+A oto jeden z tych <i>którzy</i> byli z JEzuſem / wyćiągnął rękę / y dobył miecżá ſwego / á uderzywƺy ſługę Kápłaná Nawyżƺego / ućiął mu ucho.
+Tedy mu rzekł JEzus ; Obróć miecż twój ná miejſce jego : ábowiem wƺyſcy którzy miecż biorą / od miecżá poginą.
+Azaż mniemaƺ / żebym nie mógł teraz prośić Ojcá mego / á ſtáwiłby mi więcey niż dwánaśćie wojſk Anjołów.
+Ale jákożby śię wypełniły piſmá / <i>które mówią,</i> iż śię ták muśi ſtáć.
+Onejże godźiny mówił JEzus do oney zgráje : Wyƺliśćie jáko ná zbójcę / z miecżámi y z kijmi pojimáć mię. Ná káżdy dźień śiadałem u was ucżąc w kośćiele / á nie pojimáliśćie mię.
+Aleć śię to wƺyſtko ſtáło / áby śię wypełniły piſmá Prorockie. Tedy ucżniowie <i>jego</i> wƺyſcy opuśćiwƺy go / ućiekli.
+A oni pojimawƺy JEzuſá / wiedli go do Káifaƺá Nawyżƺego Kápłaná : gdźie śię byli zebráli Náucżeni w piśmie / y Stárƺy.
+Ale Piotr ƺedł zá nim z dáleká áż do dworu Nawyżƺego Kápłaná : á wƺedƺy tám / śiedźiał z ſługámi / áby ujrzał koniec.
+A Przedniejƺy Kápłani / y Stárƺy / y wƺyſtká Rádá / ƺukáli fałƺywego świádectwá przećiwko JEzuſowi / áby go ná śmierć wydáli.
+Ale nie ználeźli. A choć wiele fałƺywych świádków przychodźiło / <i>przećię</i> nie ználeźli. Aż náoſtátek wyſtąpiwƺy dwá fałƺywi świádkowie /
+Rzekli : Ten mówił / Mogę rozwálić Kośćiół Boży / á zá trzy dni zbudowáć go.
+A wſtawƺy Nawyżƺy Kápłan / rzekł mu : Nic nie odpowiádaƺ? <i>Cóż to jeſt</i> co ći przećiwko tobie świadcżą?
+Lecż JEzus milcżał. A odpowiádájąc Nawyżƺy Kápłan / rzekł mu : Poprzyśięgam ćię przez Bogá żywego / ábyś nam powiedźiał / jeſliś ty jeſt CHryſtus / on Syn Boży?
+Rzekł mu JEzus : Tyś powiedźiał. Wƺákże powiádam wam : Od tąd ujrzyćie Syná cżłowiecżego śiedzącego ná práwicy mocy <i>Bożey,</i> y przychodzącego ná obłokách niebieſkich.
+Tedy Nawyżƺy Kápłan rozdárł ƺáty ſwoje / mówiąc : Bluźnił! Cóż jeƺcże potrzebujemy świádków? Otośćie teraz ſłyƺeli bluźnierſtwo jego.
 Cóż śię wam zda? A oni odpowiádájąc / rzekli : Winien jeſt śmierći.
-Tedy plwáli ná oblicże jego / y pięśćiámi go bili / á drudzy go policżkowáli /
-Mówiąc : Prorokuj nam / CHryſtuśie! kto jeſt ten / co ćię uderzył?
-Ale Piotr śiedźiał przed domem ná podwórzu. Tedy przyſtąpiłá do niego jedná dźiewká / mówiąc : Y tyś był z tym JEzuſem Gálilejſkim.
-A on śię záprzał przed wƺyſtkimi / mówiąc : Nie wiem / co powiádáƺ.
-A gdy on wychodźił do przyśionká / ujrzáłá go inƺá dźiewká / y rzekłá do tych / co tám byli : Y tenći był z tym JEzuſem Názáreńſkim.
-Tedy powtóre záprzał śię z przyśięgą / mówiąc : Nie znam tego cżłowieká.
-A przyſtąpiwƺy po máłej chwilce ći / co tám ſtáli / rzekli Piotrowi : Práwdźiwie y tyś jeſt z nich ; bo y mowá twojá ćiebie wydáje.
-Tedy śię pocżął przeklináć y przyśięgáć / mówiąc : Nie znam tego cżłowieká ; á zárázem kur zápiał.
-Y wſpomniał Piotr ná ſłowá JEzuſowe / który mu był powiedźiał : Pierwej niż kur zápieje / trzy kroć śię mnie záprzeƺ ; á wyƺedƺy precż / gorzko płákał.
+Tedy plwáli ná oblicże jego / y policżkowáli go : á drudzy laſkámi go bili /
+Mówiąc : Prorokuj nam CHryſtuśie / kto jeſt ten co ćię uderzył.
+Ale Piotr śiedźiał przed domem ná podwórzu. Tedy przyſtąpiłá do niego jedná dźiewká / mówiąc : Y tyś był z tym JEzuſem Gálilejſkim?
+A on śię záprzał przed wƺyſtkimi / mówiąc : Nie wiem co powiádaƺ.
+A gdy on wychodźił do Przyśionká / ujrzáłá go inƺa <i>dźiewká,</i> y rzekłá do tych co tám byli : y tenći był z tym JEzuſem Názáreńſkim.
+Tedy powtóre záprzał śię z przyśięgą / <i>mówiąc</i> : Nie znam tego cżłowieká.
+A przyſtąpiwƺy po máłey chwiłce / ći co tám ſtali / rzekli Piotrowi : Prawdźiwie y tyś jeſt z nich : bo y mowá twojá ćiebie wydawa.
+Tedy śię pocżął przeklináć y przyśięgáć / <i>mówiąc</i> : Nie znam tego cżłowieká. A zárázem kur zápiał.
+Y wſpomniał Piotr ná ſłowá JEzuſowe / który mu był powiedźiał ; Pierwey niż kur zápieje / trzy kroć śię mnie záprzyƺ. A wyƺedƺy precż / gorzko płákał.


### PR DESCRIPTION
w.45 zamieniłem "odpocżywajćie" => "odpocżywaćie" (bez j) - tak jest w 1606

Powtarzają się zamiany:
rolę -> rolą
wyrazy zakończone na "jśi" -> mają zamianę na "jƺy", np. ochotniejśi -> ochotniejƺy
ſtárśi -> starƺy

słowo pójdź w poniższych odmiannach nie ma litery "j" w środku:
pójdźże -> pódźże
pójdź -> pódź
pójdźćie -> pódźćie
pójdźćież -> pódźćież
pójdźmy -> pódźmy