### PR TITLE
1 Moj. 38.

### DIFF
--- a/1632/01-gen/38.txt
+++ b/1632/01-gen/38.txt
@@ -1,30 +1,30 @@
-Y ſtáło śię cżáſu onego / że Judás odƺedł od bráći ſwej / y wſtąpił do niektórego mężá Odolámickiego / którego imię było Chyrá.
-Y ujrzał tám Judás córkę mężá Chánánejſkiego / którego zwano Suá ; á pojąwƺy ją / wƺedł do niej.
-A oná pocżąwƺy porodźiłá ſyná / y názwáłá imię jego Her.
-Záśię pocżąwƺy porodźiłá ſyná / y názwáłá imię jego Onán.
-Nád to jeƺcże urodźiłá ſyná / y názwáłá imię jego Selá ; á Judás był w Chezybie / gdy mu go urodźiłá.
+Y ſtáło śię czáſu onego / że Judás odƺedł od bráći ſwey / y zſtąpił do <i>niektórego</i> mężá Odollámickiego / którego imię było Hirám.
+Y ujrzał tám Judás córkę mężá Chánánejſkiego / którego zwano Suáh : á pojąwƺy ją / wƺedł do niey.
+A <i>oná</i> począwƺy porodźiłá Syná / y názwáłá imię jego Her.
+Záśię począwƺy porodźiłá Syná / y názwáłá imię jego Onán.
+Nád to jeƺcze urodźiłá Syná / y názwáłá imię jego Selá / á <i>Judás</i> był w Chezybie / gdy mu go urodźiłá.
 Y dał Judás żonę Herowi pierworodnemu ſwemu / którey było imię Támár.
-Y był Her / pierworodny Judáſów / zły w ocżách Páńſkich / y zábił go Pán.
-Tedy rzekł Judás do Onáná : Wnijdź do żony brátá twego / á złącż śię z nią práwem powinowáctwá / y wzbudź naśienie brátu twemu.
-Lecż wiedząc Onán / iż to potomſtwo nie jemu być miáło / gdy wchodźił do żony brátá ſwego / tráćił z śiebie naśienie ná źiemię / áby nie wzbudźił potomſtwá brátu ſwemu.
-Y nie podobáło śię to Pánu / co Onán cżynił ; przeto go też Pán zábił.
-Zátem rzekł Judás do Támáry / niewiáſty ſwej : Mieƺkáj wdową w domu ojcá twego / áż urośnie Selá / ſyn mój / bo rzekł : By on też ſnadź nie umárł jáko bráćia jego. Y odeƺłá Támár / y mieƺkáłá w domu ojcá ſwego.
-A gdy minęło wiele dni / umárłá córká Suego / żoná Judáſowá ; y poćieƺywƺy śię Judás / ƺedł do tych / co ſtrzygli owce jego / ſám y Chyrá / towárzyƺ jego / Odolámitá / do Timnát.
-Y oznájmiono to Támárze / mówiąc : Oto / świeker twój idźie do Timnát / áby ſtrzygł owce ſwoje.
-Która złożywƺy z śiebie ƺáty wdowſtwá ſwego / okryłá śię rąbkiem / y zátknęłá śię / y uśiádłá ná rozſtániu drogi / która wiedźie do Timnát ; bo widźiáłá / że był uróſł Selá / á oná nie byłá mu dáná zá żonę.
-A ujrzáwƺy ją Judás / mniemał / że to nierządnicá / bo zákryłá byłá twárz ſwoję.
-Tedy uſtąpiwƺy do niej z drogi / mówił : Proƺę niech wnijdę do ćiebie ; ábowiem nie wiedźiał / żeby jego ſynowá byłá. Y rzekłá : Cóż mi dáƺ / żebyś do mnie wƺedł?
-Y odpowiedźiał : Poślęć koźlątko z trzody ; á oná rzekłá : Dáƺże mi záſtáw / áż mi je przyśleƺ?
-Y rzekł : Cóż ći mam dáć w záſtáw? A oná odpowiedźiáłá : Pierśćień twój / y chuſtkę twoję / y láſkę twoję / którą maƺ w ręce ſwej. Tedy jey dał / y wƺedł do niej ; á pocżęłá z niego.
-A wſtáwƺy odeƺłá / y złożywƺy z śiebie odźienie ſwoje / oblekłá śię w ƺáty wdowſtwá ſwego.
-Potem poſłał Judás koźlątko / przez rękę towárzyƺá ſwego Odolámitę / áby odebrał záſtáwę z ręki niewiáſty oney ; ále jey nie ználázł.
-Y pytał mężów miejſcá onego / mówiąc : Gdźie jeſt nierządnicá oná / która byłá ná rozſtániu tey drogi? Którzy odpowiedźieli : Nie było tu nierządnicy.
-Wróćił śię tedy do Judáſá / y rzekł : Nie ználázłem jey ; lecż y mężowie miejſcá onego powiedźieli : Nie było tu żádney nierządnicy.
-Tedy rzekł Judás : Niechże ſobie ma ten zákłád / ábyſmy nie byli ná wzgárdę ; otom poſyłał to koźlątko / á tyś jey nie ználázł.
-Y ſtáło śię / jákoby po trzech mieśiącách / powiedźiáno Judźie / mówiąc : Dopuśćiłá śię nierządu Támár / ſynowá twojá / á oto / już brzemienná jeſt z nierządu. Tedy rzekł Judás : Wywiedźćie ją / áby byłá ſpáloná.
-A gdy byłá wywiedźioná / poſłáłá do świekrá ſwego / mówiąc : Z mężá / którego te rzecży ſą / jeſtem brzemienná. Przytem powiedźiáłá : Poznáj proƺę / cżyj to pierśćień / y chuſtká / y láſká?
-Tedy poznáwƺy to Judás rzekł : Spráwiedliwƺá jeſt nád mię / poniewáżem jey nie dał Seli / ſynowi memu ; y więcey jey nie uznał.
-Y ſtáło śię / gdy przyƺedł cżás rodzeniá jey / oto bliźniętá były w żywoćie jey.
-A gdy rodźiłá / wytknęło rękę jedno dźiećię / którą ująwƺy bábá / uwiązáłá u ręki nić cżerwoną mówiąc :Ten pierwej wynijdźie.
-Y ſtáło śię / gdy záśię wćiągnęło rękę ſwoję / oto / wyƺedł brát jego ; y rzekłá : Cżemuś przerwał? ná tobie niech będźie rozerwánie ; y názwáłá imię jego Fáres.
-A potem wyƺedł brát jego / ná którego ręce byłá nić cżerwoná ; y názwáłá imię jego Zerá.
+Y był Her pierworodny Judáſów zły w oczách Páńſkich / y zábił go Pan.
+Tedy rzekł Judás do Onáná. Wnidź do żony brátá twego / á złącz śię z nią práwem powinowáctwá / y wzbudź naśienie brátu twemu.
+Lecż wiedząc Onán / iż to potomſtwo nie jemu być miáło / gdy wchodźił do żony brátá ſwego / tráćił z śiebie <i>naśienie</i> ná źiemię / áby nie wzbudźił potomſtwá brátu ſwemu.
+Y nie podobáło śię to Pánu / co <i>Onán</i> czynił : przeto go też Pan zábił.
+Zátym rzekł Judás do Támáry niewiaſtki ſwey : Mieƺkaj wdową w domu Ojcá twego / áż urośnie Selá Syn mój : Bo rzekł / By on też ſnadź nie umárł jáko bráćia jego. Y odeƺłá Támár / y mieƺkáłá w domu Ojcá ſwego.
+A gdy minęło wiele dni / umárłá córká Suáhá / żoná Judáſowá / y poćieƺywƺy śię Judás / ƺedł do tych co ſtrzygli owce jego / ſam y Chirá towárzyƺ jego Odollámitá / do Timnát.
+Y oznájmiono to Támárze mówiąc / Oto świeker twój idźie do Timnát / áby ſtrzygł owce ſwoje.
+Która złożywƺy z śiebie ƺáty wdowſtwá ſwego / okryłá śię rąbkiem / y zátknęłá śię / y uśiádłá ná rozſtániu drogi / która wiedźie do Timnát : bo widźiáłá że był uróſł Selá / á oná nie byłá mu dáná zá żonę.
+A ujrzawƺy ją Judás / mniemał że to nierządnicá / bo zákryłá byłá twarz ſwoję.
+Tedy uſtąpiwƺy do niey z drogi / mówił : Proƺę niech wnidę do ćiebie / ábowiem nie wiedźiał żeby jego ſynowa byłá : Y rzekłá / cóż mi daƺ / żebyś do mnie wƺedł?
+Y odpowiedźiał / Poślęć koźlątko z trzody / á oná rzekłá : dajże mi záſtawę áż mi je przyśleƺ?
+Y rzekł / cóżći mam dáć w záſtawie : A oná odpowiedźiáłá / pierśćień twój / y chuſtkę twoję / y laſkę twoję / którą maƺ w ręce ſwey. Tedy jey dał / y wƺedł do niey / á poczęłá z niego.
+A wſtawƺy odeƺłá / y złożywƺy z śiebie odźienie ſwoje / oblekłá śię w ƺáty wdowſtwá ſwego.
+Potym poſłał Judás koźlątko / przez rękę towárzyƺá ſwego Odollámitę áby odebrał zaſtáwę z ręki niewiáſty oney : ále jey nie ználazł.
+Y pytał mężów miejſcá onego / mówiąc : Gdźie jeſt nierządnicá oná / która <i>byłá</i> ná rozſtániu tey drogi. Którzy odpowiedźieli : Nie było tu nierządnice.
+Wróćił śię tedy do Judáſá / y rzekł. Nie ználazłem jey : lecz y mężowie miejſcá onego powiedźieli : nie było tu <i>żadney</i> nierządnice.
+Tedy rzekł Judás. Niechże ſobie ma ten <i>zakład,</i> ábyſmy niebyli ná wzgárdę : otom poſyłał to koźlątko / á tyś jey nie ználazł.
+Y ſtáło śię / jákoby po trzech mieśiącách powiedźiáno Judźie mówiąc. Dopuśćiłá śię nierządu Támár Synowá twojá : á oto już brzemienna jeſt z nierządu. Tedy rzekł Judás : Wywiedźćie ją áby byłá ſpalona.
+A gdy byłá wywiedźioná / poſłáłá do świekrá ſwego mówiąc : z mężá którego te rzeczy ſą / jeſtem brzemienna. Przytym powiedźiáłá : poznaj proƺę / czyj to pierśćień / y chuſtká / y laſká?
+Tedy poznawƺy <i>to</i> Judás / rzekł. Spráwiedliwƺa jeſt nád mię / ponieważem jey nie dał Seli ſynowi memu / y więcey jey nie uznał.
+Y ſtáło śię gdy przyƺedł czás rodzeniá jey / oto bliźniętá <i>były</i> w żywoćie jey.
+A gdy rodźiłá / wytkneło rękę <i>jedno dźiećię,</i> którą ująwƺy bábá / uwiązáłá u ręki nić czerwoną / mówiąc / Ten pierwey wynidźie.
+Y ſtáło śię / gdy záśię wćiągnoło rękę ſwoję / Oto wyƺedł brát jego : y rzekłá. Czemuś przerwał? ná tobie <i>niech będźie</i> rozerwánie / y názwáłá imię jego Fáres.
+A potym wyƺedł brát jego / ná którego ręce byłá nić czerwona : y názwáłá imię jego Zerá.

--- a/1632/01-gen/38.txt
+++ b/1632/01-gen/38.txt
@@ -2,7 +2,7 @@ Y ſtáło śię czáſu onego / że Judás odƺedł od bráći ſwey / y zſtą
 Y ujrzał tám Judás córkę mężá Chánánejſkiego / którego zwano Suáh : á pojąwƺy ją / wƺedł do niey.
 A <i>oná</i> począwƺy porodźiłá Syná / y názwáłá imię jego Her.
 Záśię począwƺy porodźiłá Syná / y názwáłá imię jego Onán.
-Nád to jeƺcze urodźiłá Syná / y názwáłá imię jego Selá / á <i>Judás</i> był w Chezybie / gdy mu go urodźiłá.
+Nád to jeƺcze urodźiłá Syná / y názwáłá imię jego Selá / á <i>Judás</i> był w Cezybie / gdy mu go urodźiłá.
 Y dał Judás żonę Herowi pierworodnemu ſwemu / którey było imię Támár.
 Y był Her pierworodny Judáſów zły w oczách Páńſkich / y zábił go Pan.
 Tedy rzekł Judás do Onáná. Wnidź do żony brátá twego / á złącz śię z nią práwem powinowáctwá / y wzbudź naśienie brátu twemu.


### PR DESCRIPTION
w.2, 12 do oceny czy pozostawić "Suáh". 
w.5 pozostawiono "Chezybie" (KJV) zamiast "Cezybie" jak w 1632 i 1660.