### PR TITLE
1 Kron.1,19.

### DIFF
--- a/1879/13-par/01.txt
+++ b/1879/13-par/01.txt
@@ -16,7 +16,7 @@ I Hewejczyka, i Archajczyka, i Symejczyka,
 I Aradejczyka, i Samarejczyka, i Chamatejczyka.
 Synowie Semowi: Elam, i Assur, i Arfachsad, i Lud, i Aram, i Chus, i Hul, i Gieter, i Mesech.
 A Arfachsad spłodził Selecha, a Selech spłodził Hebera.
-A Heberowi urodzili się dwaj synowie, z których jednemu imię było Faleg, przeto, że za jego czasów rozdzielona jest ziemia; a imię brata jego Jektan.
+A Heberowi urodzili się dwaj synowie, z których jednemu imię było Peleg, przeto, że za jego czasów rozdzielona jest ziemia; a imię brata jego Jektan.
 A Jektan spłodził Elmodada, i Salefa, i Hassarmota, i Jarecha,
 I Adorama, i Uzala, i Dekla,
 I Hebala, i Abimaela, i Sebaja,


### PR DESCRIPTION
Błąd w druku zarówno dla 1879, jak i 1632. KJV ma w obu miejscach (w.19 i 25) "Peleg"