### PR TITLE
1 Kron.2,1;3-4;9;28;32

### DIFF
--- a/1879/13-par/02.txt
+++ b/1879/13-par/02.txt
@@ -1,12 +1,12 @@
 Cić są synowie Izraelowi: Ruben, Symeon, Lewi, i Juda, Isaschar i Zabulon,
 Dan, Józef, i Benjamin, Neftali, Gad i Aser.
 Synowie Judy: Her, i Onan, i Sela. Ci trzej urodzili mu się z córki Sui Chananejskiej. Ale Her, pierworodny Judy, był złym przed oczyma Pańskiemi; przetoż go zabił.
-Tamar zasię, niewiastka jego, urodziła mu Faresa i Zarę. Wszystkich synów Judowych pięć.
+Tamar zasię, Synowa jego, urodziła mu Faresa i Zarę. Wszystkich synów Judowych pięć.
 Synowie Faresowi: Hesron i Hamuel.
 Synowie zaś Zary: Zamry, i Etan, i Heman, i Chalkol, i Darda; wszystkich tych było pięć.
 A synowie Zamrego: Charmi, wnuk Acharowy, który zamięszanie uczynił w Izraelu, zgrzeszywszy kradzieżą rzeczy przeklętych.
 A synowie Etanowi: Azaryjasz.
-A synowie Esronowi, którzy mu się urodzili: Jerameel, i Ram, i Chalubaj.
+A synowie Hesronowi, którzy mu się urodzili: Jerameel, i Ram, i Chalubaj.
 Ale Ram spłodził Aminadaba, a Aminadab spłodził Naasona, książęcia synów Judzkich.
 A Naason spłodził Salmona, a Salmon spłodził Booza.
 A Booz spłodził Obeda, a Obed spłodził Isajego.
@@ -25,11 +25,11 @@ A gdy umarł Hesron w Kaleb Efrata, tedy żona Hesronowa Abija porodziła mu Ass
 Byli też synowie Jerameelowi, pierworodnego Hesronowego: Pierworodny Ram, po nim Buna, i Oren, i Osem z Abii.
 Miał także drugą żonę Jerameel, imieniem Atara; ta jest matka Onamowa.
 Ale synowie Ramowi, pierworodnego Jerameelowego, byli: Maas, i Jamin, i Achar.
-Byli też synowie Onamowi: Semaj, i Jada, a synowie Semejego: Nadad i Abisur;
+Byli też synowie Onamowi: Sammaj, i Jada, a synowie Sammajego: Nadad i Abisur;
 A imię żony Abisurowej Abihail, która mu urodziła Achobbana i Molida.
 Synowie Nadabowi: Saled i Affaim; lecz Saled umarł bez potomstwa.
 A synowie Affaimowi Jesy; a synowie Jesy Sesan, a córka Sesana Achialaj.
-A synowie Jady, brata Semejego, Jeter i Jonatan; ale Jeter umarł bez potomstwa.
+A synowie Jady, brata Sammajego, Jeter i Jonatan; ale Jeter umarł bez potomstwa.
 A synowie Jonatanowi: Falet i Zyza. Cić byli synowie Jerameelowi.
 Lecz nie miał Sesan synów, jedno córki; miał też Sesan sługę Egipczanina, imieniem Jeracha.
 I dał Sesan córkę Jerachowi, słudze swemu, za żonę, która mu urodziła Etaja.

--- a/1879/13-par/02.txt
+++ b/1879/13-par/02.txt
@@ -1,6 +1,6 @@
-Cić są synowie Izraelowi: Ruben, Symeon, Lewi, i Juda, Isaschar i Zabulon,
+Cić są synowie Izraelowi: Ruben, Symeon, Lewi, i Judas, Isaschar i Zabulon,
 Dan, Józef, i Benjamin, Neftali, Gad i Aser.
-Synowie Judy: Her, i Onan, i Sela. Ci trzej urodzili mu się z córki Sui Chananejskiej. Ale Her, pierworodny Judy, był złym przed oczyma Pańskiemi; przetoż go zabił.
+Synowie Judasowi: Her, i Onan, i Sela. Ci trzej urodzili mu się z córki Sui Chananejskiej. Ale Her, pierworodny Judy, był złym przed oczyma Pańskiemi; przetoż go zabił.
 Tamar zasię, Synowa jego, urodziła mu Faresa i Zarę. Wszystkich synów Judowych pięć.
 Synowie Faresowi: Hesron i Hamuel.
 Synowie zaś Zary: Zamry, i Etan, i Heman, i Chalkol, i Darda; wszystkich tych było pięć.

--- a/1879/13-par/02.txt
+++ b/1879/13-par/02.txt
@@ -1,6 +1,6 @@
-Cić są synowie Izraelowi: Ruben, Symeon, Lewi, i Judas, Isaschar i Zabulon,
+Cić są synowie Izraelowi: Ruben, Symeon, Lewi, i Juda, Isaschar i Zabulon,
 Dan, Józef, i Benjamin, Neftali, Gad i Aser.
-Synowie Judasowi: Her, i Onan, i Sela. Ci trzej urodzili mu się z córki Sui Chananejskiej. Ale Her, pierworodny Judy, był złym przed oczyma Pańskiemi; przetoż go zabił.
+Synowie Judy: Her, i Onan, i Sela. Ci trzej urodzili mu się z córki Sui Chananejskiej. Ale Her, pierworodny Judy, był złym przed oczyma Pańskiemi; przetoż go zabił.
 Tamar zasię, Synowa jego, urodziła mu Faresa i Zarę. Wszystkich synów Judowych pięć.
 Synowie Faresowi: Hesron i Hamuel.
 Synowie zaś Zary: Zamry, i Etan, i Heman, i Chalkol, i Darda; wszystkich tych było pięć.


### PR DESCRIPTION
w.4. Synowa (1660) zgadza się też z KJV "daughter in law"; podobnie też 1 Sam.4,19. ("Synowa")
w.9. Hesronowi (por. w.5 i 25.; KJV ma w tych miejscach zawsze to samo imię)
w.28. i 32. (por. w.44-45. i KJV który ma wszędzie to samo imię)

błąd jest zarówno w 1632, jak i 1879.

Ujednolicenie pisowni w przyszłości - słowa Juda / Judas:
w.1. por 1 Moj.35,23. 1 Moj.38. 1 Kron.5,2.; też KJV ma tutaj i 1 Kron.5,2. to samo imię.
w.3. por 1 Moj.38,1-4 z 1 Kron.2,3.; zaproponowana odmiana "Judasowi" zaczerpnięta z 1 Moj.38,12.: "żona Judasowa" albo np. 1 Kron.5,11 "synowie Gadowi".
Także w dalszych rozdziałach 1 Kron. są wystąpienia od słowa Juda, a nie Judas.
 1 Moj.38,7.; 1 Moj.46,12.

Po przeanalizowaniu tekstu, znacznie częściej występuje podstawowe słowo Juda niż Judas - słowo Judas i pochodne występują głównie tylko w 1 Moj. i zapewne tam powinna być zamiana Judas -> Juda oraz wyrazy pochodne.