### PR TITLE
1 Kron.3,21.

### DIFF
--- a/1879/13-par/03.txt
+++ b/1879/13-par/03.txt
@@ -18,7 +18,7 @@ A synowie Jechonijasza więźnia: Salatyjel syn jego.
 A Salatyjelowi: Malchiram, i Fadajasz, i Seneser, Jekiemija, Hosama, i Nadabija.
 A synowie Fadajaszowi: Zorobabel, i Semej; a syn Zorobabelowy Mesollam, i Hananijasz, i Selomit, siostra ich.
 A Mesollamowi: Hasuba, i Ohol, i Barachyjasz, i Hazadyjasz Josabchesed, pięć synów.
-A syn Hananijaszowy: Faltyjasz, i Jesajasz; synowie Rafajaszowi, synowie Arnanaszowi, synowie Obadyjaszowi, synowie Sechenijaszowi.
+A synowie Hananijaszowi: Faltyjasz, i Jesajasz; synowie Rafajaszowi, synowie Arnanaszowi, synowie Obadyjaszowi, synowie Sechenijaszowi.
 A synowie Sechenijaszowi: Semejasz; a synowie Semejaszowi: Chattus, i Igal, i Baryja, i Naaryjasz, i Safat; sześć synów.
 A synowie Naaryjaszowi: Elijenaj, i Ezechyjasz, i Esrykam, trzej synowie.
 A synowie Elijenajego: Hodawijasz i Elijasub, i Felejasz, i Akkub, i Jochanan, i Dalajasz, i Anani, siedm synów.


### PR DESCRIPTION
w.17.  możliwe że słowa "więźnia" jest użyte niepoprawnie - por. KJV oraz jest słowo synowie na początku wersetu.
Także w.18 niepewny - w KJV jest inny początek. Można próbować porównać z hebrajskim oryginałem np.:
http://www.biblia-internetowa.pl/1Kron/3/18.html
https://wordproject.org/bibles/he/13/3.htm#0

w.21. KJV ma "sons"

Błąd jest zarówno w 1632, jak i 1879