### PR TITLE
1 Kron.6,19;29.

### DIFF
--- a/1879/13-par/06.txt
+++ b/1879/13-par/06.txt
@@ -16,7 +16,7 @@ Ale Jozedek poszedł w niewolę, gdy Pan przeniósł Judę i Jeruzalem przez Nab
 Synowie Lewi: Gierson, Kaat, i Merary.
 A teć są imiona synów Giersonowych: Lobni i Semei.
 A synowie Kaatowi: Amram i Izaar, i Hebron, i Husyjel.
-Synowie Merarego: Macheli, i Muzy. A teć są domy Lewitów według ojców ich.
+Synowie Merarego: Machli, i Muzy. A teć są domy Lewitów według ojców ich.
 Giersonowi: Lobni syn jego, Jachat syn jego, Zamma syn jego;
 Joach syn jego, Iddo syn jego, Zara syn jego, Jetraj syn jego.
 Synowie Kaatowi: Aminadab syn jego, Kore syn jego, Aser syn jego.
@@ -26,7 +26,7 @@ A synowie Elkanowi: Amasaj i Achymot.
 Elkana. Synowie Elkanowi: Sofaj syn jego, i Nahat syn jego;
 Elijab syn jego, Jerobam syn jego, Elkana syn jego.
 A synowie Samuelowi: Pierworodny Wassni i Abijas.
-Synowie Merarego: Mahali; Lobni syn jego, Symej syn jego, Uza syn jego;
+Synowie Merarego: Machli; Lobni syn jego, Symej syn jego, Uza syn jego;
 Symha syn jego, Haggijasz syn jego, Asajasz syn jego.
 Ci są, których postanowił Dawid do śpiewania w domu Pańskim, gdy tam postawiono skrzynię.
 I służyli przed przybytkiem namiotu zgromadzenia, śpiewając, aż zbudował Salomon dom Pański w Jeruzalemie, i stali według porządku swego na służbie swojej.

--- a/1879/13-par/06.txt
+++ b/1879/13-par/06.txt
@@ -16,7 +16,7 @@ Ale Jozedek poszedł w niewolę, gdy Pan przeniósł Judę i Jeruzalem przez Nab
 Synowie Lewi: Gierson, Kaat, i Merary.
 A teć są imiona synów Giersonowych: Lobni i Semei.
 A synowie Kaatowi: Amram i Izaar, i Hebron, i Husyjel.
-Synowie Merarego: Machli, i Muzy. A teć są domy Lewitów według ojców ich.
+Synowie Merarego: Maheli, i Muzy. A teć są domy Lewitów według ojców ich.
 Giersonowi: Lobni syn jego, Jachat syn jego, Zamma syn jego;
 Joach syn jego, Iddo syn jego, Zara syn jego, Jetraj syn jego.
 Synowie Kaatowi: Aminadab syn jego, Kore syn jego, Aser syn jego.
@@ -26,7 +26,7 @@ A synowie Elkanowi: Amasaj i Achymot.
 Elkana. Synowie Elkanowi: Sofaj syn jego, i Nahat syn jego;
 Elijab syn jego, Jerobam syn jego, Elkana syn jego.
 A synowie Samuelowi: Pierworodny Wassni i Abijas.
-Synowie Merarego: Machli; Lobni syn jego, Symej syn jego, Uza syn jego;
+Synowie Merarego: Maheli; Lobni syn jego, Symej syn jego, Uza syn jego;
 Symha syn jego, Haggijasz syn jego, Asajasz syn jego.
 Ci są, których postanowił Dawid do śpiewania w domu Pańskim, gdy tam postawiono skrzynię.
 I służyli przed przybytkiem namiotu zgromadzenia, śpiewając, aż zbudował Salomon dom Pański w Jeruzalemie, i stali według porządku swego na służbie swojej.


### PR DESCRIPTION
Błąd jest też w 1632

KJV ma w obu miejscach jedno imię;
Po hebrajsku to chyba מחלי  (też w obu miejscach to samo słowo)

Moja korekta jest jedynie propozycją.

Przy próbie porównania w.19. i 29. w google tłumaczu wyszło mi coś takiego:
https://translate.google.pl/?hl=pl&sl=auto&tl=pl&text=%D7%91%D7%A0%D7%99%20%D7%9E%D7%A8%D7%A8%D7%99%20%D7%9E%D7%97%D7%9C%D7%99%20%D7%9C%0A%0A%0A%D7%91%D7%A0%D7%99%20%D7%9E%D7%A8%D7%A8%D7%99%20%D7%9E%D7%97%D7%9C%D7%99%20%D7%95%D7%9E%D7%A9%D7%99%20&op=translate

Po przeanalizowaniu tekstu - najczęściej w tekście występuje "Maheli" np 1 Kron.23.; 1 Kron.24.