### PR TITLE
1 Moj. 46.

### DIFF
--- a/1632/01-gen/46.txt
+++ b/1632/01-gen/46.txt
@@ -1,34 +1,34 @@
-A ták jechał Izráel ze wƺyſtkim / co miał / á przyjecháwƺy do Beerſeby / ofiárował ofiáry Bogu ojcá ſwego Izááká.
-Y rzekł Bóg do Izráelá w widzeniu nocnem / mówiąc : Jákóbie / Jákóbie ; á on odpowiedźiał : Owom ja.
-Y rzekł : Jam jeſt Bóg / Bóg ojcá twojego ; nie bój śię zſtąpić do Egiptu / bo ćię tám w naród wielki rozmnożę.
-Ja zſtąpię z tobą do Egiptu / y Ja ćię z támtąd tákże záśię wywiodę / á Józef położy rękę ſwoję ná ocży twoje.
-Y powſtał Jákób z Beerſeby ; y wźięli ſynowie Izráelowi Jákóbá ojcá ſwego / y dźiátki ſwe / y żony ſwe ná wozy / które był poſłał Fáráo / áby go przywieźiono.
-Pobráli też bydłá ſwe / y májętność ſwoję / którey byli nábyli w źiemi Chánánejſkiej / y przyjecháli do Egiptu / Jákób y wƺyſtká rodźiná jego z nim ;
-Syny ſwe / y ſyny ſynów ſwych / córki ſwe y córki ſynów ſwych / y wƺyſtko naśienie ſwoje prowádźił z ſobą do Egiptu.
-A teć ſą imioná ſynów Izráelowych / którzy weƺli do Egiptu : Jákób y ſynowie jego : pierworodny Jákóbów Ruben.
-A ſynowie Rubenowi : Henoch / y Fállu / y Heſron y Chármi.
-A ſynowie Symeonowi : Jemuel / y Jámyn / y Achod / y Jáchyn / y Sochár / y Saul / ſyn niewiáſty Chánánejſkiej.
-Synowie też Lewiego : Gerſon / Káát / y Meráry.
-A ſynowie Judáſowi : Her / y Onán / y Selá / y Fáres / y Zárá ; ále umárł Her y Onán w źiemi Chánánejſkiej. A byli ſynowie Fáreſowi : Heſron y Hámuel.
-A ſynowie Iſáƺárowi : Tolá / y Fuá / y Job / y Simron.
-Synowie záś Zábulonowi : Záred / y Elon / y Jáleel.
-A ćić ſą ſynowie Lii / które urodźiłá Jákóbowi w Pádánie Syryjſkim / y Dyná córká jego ; wƺyſtkich duƺ ſynów jego / y córek jego / trzydźieśći y trzy.
-A ſynowie Gádowi : Sefon / y Aggi / Suny / y Eſebon / Ery / y Arody / y Areli.
-A ſynowie Aſer : Jemná / y Jeſuá / y Iſui / y Beryjá / y Será / śioſtrá ich. A ſynowie Beryjego : Heber / y Melchyjel.
-Cić ſą ſynowie Zelfy / którą był dał Lábán Lii / córce ſwej / których oná urodźiłá Jákóbowi / ƺeſnaśćie duƺ.
-Synowie Rácheli / żony Jákóbowej : Józef y Benjámin.
-Józefowi záś urodźili śię ſynowie w źiemi Egipſkiej / które mu urodźiłá Aſenát / córká Potyfárá / kśiążęćiá Ońſkiego : Mánáſes y Efráim.
-A ſynowie Benjáminowi : Belá / y Bechor / y Aſbel / Gerá / y Náámán / Echy y Ros / Mupim / y Chupim / y Ared.
-Cić ſą ſynowie Rácheli / którzy śię urodźili Jákóbowi ; wƺyſtkich duƺ cżternaśćie.
-A ſynowie Dánowi : Chuſym.
-Synowie też Neftálimowi : Jáchſyjel / y Gunny / y Jeſer / y Selem.
-Ci ſą ſynowie Báli / którą był dał Lábán Rácheli / córce ſwej / która je urodźiłá Jákóbowi ; wƺyſtkich duƺ śiedm.
-Wƺyſtkie duƺe / które przyƺły z Jákóbem do Egiptu / co wyƺły z biódr jego / okrom żon ſynów Jákóbowych / wƺyſtkich duƺ było ƺeśćdźieśiąt y ƺeść.
-A ſynów Józefowych / którzy mu śię urodźili w Egipćie / duƺ dwie. A ták wƺyſtkich duƺ domu Jákóbowego / które weƺły do Egiptu / było śiedmdźieśiąt.
-Y poſłał przed ſobą Judáſá do Józefá / áby mu oznájmił pierwej / niżby przyjechał do Goſen. Y przyjecháli do źiemi Goſen.
-A záprzągƺy Józef wóz ſwój / wyjechał przećiw Izráelowi / ojcu ſwemu / do Goſen ; á ujrzáwƺy go ( Jákób ) pádł ná ƺyję jego / y płákał ná ƺyi jego chwilę.
-Tedy rzekł Izráel do Józefá : Niechże już umrę / gdym ujrzał oblicże twoje / poniewáżeś ty jeƺcże żyw.
-Zátem rzekł Józef do bráći ſwej y do domu ojcá ſwego : Pojádę / á opowiem Fáráonowi / y rzekę mu : Bráćia moi y dom ojcá mego / którzy byli w źiemi Chánánejſkiej / przyjecháli do mnie ;
-A ći mężowie ſą páſterze trzód / bo śię báwili chowániem bydłá ; przeto owce ſwoje / y woły ſwoje / y wƺyſtko / co mieli / przywiedli.
-A ták gdy was przyzowie Fáráo / y ſpytá : Cżym śię báwićie?
-Odpowiećie : Páſterze byli ſłudzy twoi od dźiećińſtwá náƺego áż dotąd / y my y ojcowie náśi ; á to dla tego / ábyśćie mogli mieƺkáć w źiemi Goſen / bo obrzydłośćią Egipcżánom jeſt wƺelki páſterz bydłá.
+A ták jáchał Izráel ze wƺyſtkim co miał / á przyjáchawƺy do Beerſeby / ofiárował ofiáry Bogu Ojcá ſwego Izááká.
+Y rzekł Bóg do Izráelá w widzeniu nocnym / mówiąc : Jákóbie / Jákóbie : A on odpowiedźiał : Owom ja.
+Y rzekł : Jam <i>jeſt</i> Bóg / Bóg Ojcá twojego : nie bój śię zſtąpić do Egiptu / bo ćię tám w naród wielki rozmnożę.
+Ja zſtąpię z tobą do Egiptu / y ja ćię z támtąd tákże záśię wywiodę / á Józef położy rękę ſwoję ná oczy twoje :
+Y powſtał Jákób z Beerſeby. Y wźięli Synowie Izráelowi Jákóbá Ojcá ſwego / y dźiatki ſwe / y żony ſwe ná wozy które był poſłał Fáráo / áby go przywieźiono.
+Pobráli też bydłá ſwe / y májętność ſwoję / którey byli nábyli w źiemi Chánánejſkiey / y przyjácháli do Egiptu / Jákób / y wƺyſtká rodźiná jego z nim.
+Syny ſwe / Syny Synów ſwych / córki ſwe / y córki ſynów ſwych / y wƺyſtko naśienie ſwoje prowádźił z ſobą do Egiptu.
+A teć <i>ſą</i> imioná Synów Izráelowych którzy weƺli do Egiptu / Jákób y Synowie jego : pierworodny Jákóbów Ruben.
+A Synowie Rubenowi Henoch / y Fallu / y Heſron / y Chármi.
+A ſynowie Symeonowi / Jemuel / y Jámin / y Achod / y Jáchin / y Sochár y Saul / ſyn <i>niewiáſty</i> Chánánejſkiey.
+Synowie też Lewiego Gerſon / Cáát / y Meráry.
+A ſynowie Judáſowi / Her / y Onán / y Selá / y Fáres / y Zárá : ále umarł Her / y Onán w źiemi Chánánejſkiey : A byli Synowie Fáreſowi Heſron y Hámulá.
+A ſynowie Iſáƺárowi / Tolá / y Fuá / y Job / y Simron.
+Synowie záś Zábulonowi / Sáred / y Elon / y Jáhelel.
+A ćić ſą ſynowie Liy / które urodźiłá Jákóbowi w Pádánie Syryjſkim / y Diná córká jego / wƺyſtkich duƺ ſynów jego / y córek jego trzydźieśći y trzy.
+A ſynowie Gádowi Sefon / y Aggi / Suni / y Eſebon / Hery y Arody / y Areli.
+A ſynowie Aſer / Jámná / y Jeſuá / y Ieſui / y Beriá / y Será śioſtrá ich. A ſynowie Beriego / Heber / y Melchiel.
+Cić <i>ſą</i> ſynowie Zelfy / którą był dał Lábán Liy córce ſwey / których oná urodźiłá Jákóbowi / ƺeſnaśćie duƺ.
+Synowie Ráchele żony Jákóbowey / Józef / y Benjámin.
+Józefowi záś urodźili śię <i>Synowie</i> w źiemi Egipſkiey / które mu urodźiłá Aſenát córká Potyfárá Kśiążęćiá Ońſkiego / Mánáſſes y Efráim.
+A ſynowie Benjáminowi Belá / y Bechor / y Asbel / Gerá / y Náámán / Echy / y Ros / Mofim / y Ofim / y Ared.
+Cić <i>ſą</i> ſynowie Ráchele którzy śię urodźili Jákóbowi / wƺyſtkich duƺ czternaśćie.
+A ſynowie Dánowi Chuſim.
+Synowie też Neftálimowi Jáſiel / y Guni / y Jeſer / y Sálem.
+Ci <i>ſą</i> ſynowie Bále / którą był dał Lábán Rácheli córce ſwey / która je urodźiłá Jákóbowi / wƺyſtkich duƺ śiedm.
+Wƺyſtkie duƺe które przyƺły z Jákóbem do Egiptu co wyƺły z biódr jego / okrom żon ſynów Jákóbowych / wƺyſtkich duƺ było ƺeśćdźieśiąt y ƺeść.
+A ſynów Józefowych którzy mu śię urodźili w Egipćie / duƺ dwie. <i>A ták</i> wƺyſtkich duƺ domu Jákóbowego / które weƺły do Egiptu <i>było</i> śiedmdźieśiąt.
+Y poſłał przed ſobą Judáſá do Józefá áby mu oznájmił pierwey niżby <i>przyjáchał</i> do Geſen. Y przyjácháli do źiemie Geſen.
+A záprzągƺy Józef wóz ſwój / wyjáchał przećiw Izráelowi Ojcu ſwemu do Geſen / á ujrzawƺy go / padł ná ƺyję jego / y płákał ná ƺyji jego chwilę.
+Tedy rzekł Izráel do Józefá : Niechże już umrę / gdym ujrzał oblicze twoje / ponieważeś ty jeƺcze żyw.
+Zátym rzekł Józef do Bráćij ſwey / y do domu Ojcá ſwego / pojádę / á opowiem Fáráonowi / y rzekę mu : Bráćia moji / y dom Ojcá mego / którzy byli w źiemi Chánánejſkiey / przyjácháli do mnie.
+A <i>ći</i> mężowie <i>ſą</i> páſterze trzód / bo śię báwili chowániem bydłá / przeto owce ſwoje / y woły ſwoje / y wƺyſtko co mieli przywiedli.
+A ták gdy was przyzowie Fáráo / y ſpyta / czym śię báwićie /
+Odpowiećie : páſterze byli ſłudzy twoji od dźiećińſtwá náƺego áż do tąd / y my / y Ojcowie náƺy. <i>A to dla tego</i> ábyśćie mogli mieƺkáć w źiemi Geſen : bo obrzydłośćią Egipczánom jeſt wƺelki páſterz bydłá.


### PR DESCRIPTION
W związku z wieloma różnicami, pisownie imion pozostawiono wg 1632 (do oceny). Choć 1660 wydaję się je poprawnie korygować.

"Synowie" czy "ſynowie" (wielka / mała litera) pozostawiono zgodnie z 1632.