### PR TITLE
Mat.22.

### DIFF
--- a/1632/40-mat/22.txt
+++ b/1632/40-mat/22.txt
@@ -20,14 +20,14 @@ Pokażćie mi monetę cżynƺową : A oni mu podáli groƺ.
 Y rzekł im ; Cżyjże to obraz y napis?
 Rzekli mu ; Ceſárſki. Tedy im rzekł ; Oddawajćież tedy co jeſt Ceſárſkiego Ceſárzowi : á co jeſt Bożego / Bogu.
 To uſłyƺawƺy / zádźiwili śię : á opuśćiwƺy go / odeƺli.
-Dniá onego przyƺli do niego Sáduceuƺowie / którzy mówią iż niemáƺ <i>zmartwych</i> wſtánia : y pytáli go /
+Dniá onego przyƺli do niego Sáduceuƺowie / którzy mówią iż niemáƺ <i>zmartwych</i>wſtánia : y pytáli go /
 Mówiąc ; Náucżyćielu / Mojzeƺ powiedźiał : Jeſliby kto umárł nie májąc dźieći / áby brát jego práwem powinowáctwá pojął żonę jego / y wzbudźił naśienie brátu ſwemu.
 Było tedy u nas śiedm bráći : á pierwƺy pojąwƺy żonę / umárł : á nie májąc naśienia / zoſtáwił żonę ſwoję brátu ſwemu.
 Tákże też wtóry / y trzeći ; áż do śiódmego.
 A ná oſtátek po wƺyſtkich umárłá y oná Niewiáſtá.
-Przetoż / przy <i>zmartwych</i> wſtániu / któregoż z tych śiedmi będźie żoną : gdyż ją wƺyſcy mieli?
+Przetoż / przy <i>zmartwych</i>wſtániu / któregoż z tych śiedmi będźie żoną : gdyż ją wƺyſcy mieli?
 A odpowiádájąc JEzus / rzekł im ; Błądźićie / nie będąc powiádomi piſmá / áni mocy Bożey.
-Abowiem przy <i>zmartwych</i> wſtániu / áni śię żenić áni zá mąż chodźić będą : ále będą jáko Anjołowie Boży w niebie.
+Abowiem przy <i>zmartwych</i>wſtániu / áni śię żenić áni zá mąż chodźić będą : ále będą jáko Anjołowie Boży w niebie.
 A o powſtániu umárłych / nie cżytáliśćie co wam powiedźiano od Bogá mówiącego?
 Jam jeſt Bóg Abráhámów / y Bóg Izááków / y Bóg Jákóbów : Bóg / nie jeſtći Bogiem umárłych / ále żywych.
 A uſłyƺawƺy <i>to</i> lud / zdumiał śię nád náuką jego.

--- a/1632/40-mat/22.txt
+++ b/1632/40-mat/22.txt
@@ -1,46 +1,46 @@
-A odpowiádájąc JEzus / záśię im rzekł w podobieńſtwách / mówiąc :
-Podobne jeſt króleſtwo niebieſkie cżłowiekowi królowi / który ſpráwił weſele ſynowi ſwemu ;
-Y poſłał ſługi ſwe / áby wezwáli záproƺonych ná weſele ; ále nie chćieli przyść.
-Znowu poſłał inƺe ſługi / mówiąc : Powiedzćie záproƺonym : Otom obiád mój nágotował / woły moje y co było kármnego / pobito / y wƺyſtko gotowe / pójdźćież ná weſele.
-Ale oni zániedbáwƺy odeƺli / jeden do roli ſwojey / á drugi do kupiectwá ſwego ;
-A drudzy pojmáwƺy ſługi jego / zelżyli y pobili je.
-Co gdy król uſłyƺał / rozgniewał śię / á poſłáwƺy wojſká ſwoje / wytráćił one morderce / y miáſto ich zápálił.
-Tedy rzekł ſługom ſwoim : Weſeleć wpráwdźie jeſt gotowe ; lecż záproƺeni nie byli godni.
-Przetoż idźćie ná rozſtánia dróg / á kogokolwiek znájdźiećie / wezwijćie ná weſele.
-Tedy wyƺedƺy oni ſłudzy ná drogi / zgromádźili wƺyſtkie / którekolwiek ználeſli / złe y dobre / y nápełnione jeſt weſele gośćmi.
-A wƺedƺy król / áby oglądał gośćie / obácżył tám cżłowieká nieodźiánego ƺátą weſelną ;
-Y rzekł mu : Przyjáćielu! jákoś tu wƺedł / nie májąc ƺáty weſelney? A on zámilknął.
-Tedy rzekł król ſługom : Związáwƺy nogi y ręce jego / weźmijćie go / á wrzuććie do ćiemnośći zewnętrznych / tám będźie płácż y zgrzytánie zębów.
+Tedy odpowiádájąc JEzus / záśię im rzekł w podobieńſtwách / mówiąc ;
+Podobne jeſt króleſtwo niebieſkie cżłowiekowi Królowi / który ſpráwił weſele Synowi ſwemu.
+Y poſłał ſługi ſwe áby wezwáli záproƺonych ná weſele : ále nie chćieli przyść.
+Znowu poſłał inƺe ſługi / mówiąc : Powiedzćie záproƺonym ; Otom obiad mój nágotował / woły moje y co było karmnego pobito / y wƺyſtko gotowo : Pódźćież ná weſele.
+Ale oni zániedbawƺy / odeƺli / jeden do roli ſwojey / á drugi do kupiectwá ſwego.
+A drudzy pojimawƺy ſługi jego / zelżyli y pobili <i>je</i>.
+Co gdy Król uſłyƺał / rozgniewał śię : á poſławƺy wojſká ſwoje / wytráćił one morderze ; y miáſto ich zápalił.
+Tedy rzekł ſługom ſwojim ; Weſeleć w prawdźie jeſt gotowe : lecż záproƺeni nie byli godni.
+Przetoż idźćie ná rozſtánia dróg : á kogokolwiek znajdźiećie / wezwićie ná weſele.
+Tedy wyƺedƺy oni ſłudzy ná drogi / zgromádźili wƺyſtkie którekolwiek ználeźli / złe y dobre : y nápełnione jeſt weſele gośćmi.
+A wƺedƺy Król áby oglądał gośćie ; obacżył tám cżłowieká nieodźianego ƺátą weſelną /
+Y rzekł mu ; Przyjaćielu / jákoś tu wƺedł / nie májąc ƺáty weſelney? A on zámilknął.
+Tedy rzekł Król ſługom ; Związawƺy nogi y ręce jego / weźmićie go / á wrzuććie do ćiemnośći zewnętrznych : tám będźie płácż y zgrzytánie zębów.
 Abowiem wiele jeſt wezwánych / ále máło wybránych.
-Tedy odƺedƺy Fáryzeuƺowie ucżynili rádę / jákoby go uśidlili w mowie.
-Y poſłáli do niego ucżnie ſwoje z Herodyjány / mówiąc : Náucżyćielu! wiemy / żeś jeſt práwdźiwy / y drogi Bożey w práwdźie ucżyƺ / á niedbáƺ ná nikogo ; ábowiem niepátrzyƺ ná oſobę ludzką.
-Przetoż powiedz nam / coć śię zda? Godźili śię dáć cżynƺ ceſárzowi / cżyli nie?
-Ale JEzus poznáwƺy złość ich / rzekł : Cżemuż mię kuśićie / obłudnicy?
-Pokáżćie mi monetę cżynƺową ; á oni mu podáli groƺ.
-Y rzekł im : Cżyjże to obraz y nápis?
-Rzekli mu : Ceſárſki. Tedy im rzekł : Oddáwájćież tedy / co jeſt ceſárſkiego / ceſárzowi / á co jeſt Bożego / Bogu.
-To uſłyƺáwƺy / zádźiwili śię / á opuśćiwƺy go / odeƺli.
-Dniá onego przyƺli do niego Sáduceuƺowie / którzy mówią / iż niemáƺ zmartwychwſtánia / y pytáli go /
-Mówiąc : Náucżyćielu! Mojzeƺ powiedźiał : Jeſliby kto umárł / niemájąc dźieći / áby brát jego práwem powinowáctwá pojął żonę jego / y wzbudźił naśienie brátu ſwemu.
-Było tedy u nas śiedm bráći ; á pierwƺy pojąwƺy żonę / umárł / á nie májąc náśieniá / zoſtáwił żonę ſwoję brátu ſwemu.
-Tákże też wtóry y trzeći / áż do śiódmego.
-A ná oſtátek po wƺyſtkich umárłá y oná niewiáſtá.
-Przetoż przy zmartwychwſtániu / któregoż z tych śiedmiu będźie żoną / gdyż ją wƺyſcy mieli?
-A odpowiádájąc JEzus rzekł im : Błądźićie / nie będąc powiádomieni Piſmá / áni mocy Bożey.
-Abowiem przy zmartwychwſtániu áni śię żenić / áni zá mąż chodźić nie będą / ále będą jáko Aniołowie Boży w niebie.
-A o powſtániu umárłych nie cżytáliśćie / co wam powiedźiáno od Bogá mówiącego :
-Jam jeſt Bóg Abráhámá / y Bóg Izááká / y Bóg Jákóbá? Bóg nie jeſtći Bogiem umárłych / ále żywych.
-A uſłyƺáwƺy to lud / zdumiał śię nád náuką jego.
+Tedy odƺedƺy Fáryzeuƺowie / ucżynili rádę / jákoby go uśidlili w mowie.
+Y poſłáli do niego ucżnie ſwoje z Herodyány / mówiąc ; Náucżyćielu / Wiemy żeś jeſt prawdźiwy / y drogi Bożey w prawdźie ucżyƺ / á niedbaƺ ná nikogo : ábowiem nie pátrzaƺ ná oſobę ludzką.
+Przetoż / powiedz nam coć śię zda? Godźili śię dáć cżynƺ Ceſárzowi / cżyli nie?
+Ale JEzus poznawƺy złość ich / rzekł ; Cżemuż mię kuśićie obłudnicy?
+Pokażćie mi monetę cżynƺową : A oni mu podáli groƺ.
+Y rzekł im ; Cżyjże to obraz y napis?
+Rzekli mu ; Ceſárſki. Tedy im rzekł ; Oddawajćież tedy co jeſt Ceſárſkiego Ceſárzowi : á co jeſt Bożego / Bogu.
+To uſłyƺawƺy / zádźiwili śię : á opuśćiwƺy go / odeƺli.
+Dniá onego przyƺli do niego Sáduceuƺowie / którzy mówią iż niemáƺ <i>zmartwych</i> wſtánia : y pytáli go /
+Mówiąc ; Náucżyćielu / Mojzeƺ powiedźiał : Jeſliby kto umárł nie májąc dźieći / áby brát jego práwem powinowáctwá pojął żonę jego / y wzbudźił naśienie brátu ſwemu.
+Było tedy u nas śiedm bráći : á pierwƺy pojąwƺy żonę / umárł : á nie májąc naśienia / zoſtáwił żonę ſwoję brátu ſwemu.
+Tákże też wtóry / y trzeći ; áż do śiódmego.
+A ná oſtátek po wƺyſtkich umárłá y oná Niewiáſtá.
+Przetoż / przy <i>zmartwych</i> wſtániu / któregoż z tych śiedmi będźie żoną : gdyż ją wƺyſcy mieli?
+A odpowiádájąc JEzus / rzekł im ; Błądźićie / nie będąc powiádomi piſmá / áni mocy Bożey.
+Abowiem przy <i>zmartwych</i> wſtániu / áni śię żenić áni zá mąż chodźić będą : ále będą jáko Anjołowie Boży w niebie.
+A o powſtániu umárłych / nie cżytáliśćie co wam powiedźiano od Bogá mówiącego?
+Jam jeſt Bóg Abráhámów / y Bóg Izááków / y Bóg Jákóbów : Bóg / nie jeſtći Bogiem umárłych / ále żywych.
+A uſłyƺawƺy <i>to</i> lud / zdumiał śię nád náuką jego.
 Lecż gdy uſłyƺeli Fáryzeuƺowie / że záwárł uſtá Sáduceuƺom / zeƺli śię weſpół.
-Y ſpytał go jeden z nich / zakonnik / kuƺąc go y mówiąc :
-Náucżyćielu! które jeſt nájwiękƺe przykazánie w zakonie?
-A JEzus mu rzekł : Będźieƺ miłował Páná / Bogá twego / ze wƺyſtkiego ſercá twego / y ze wƺyſtkiej duƺy twojey y ze wƺyſtkiej myśli twojey ;
-To jeſt pierwƺe y nájwiękƺe przykazánie.
+Y ſpytał go jeden z nich Zakonnik / kuƺąc go y mówiąc ;
+Náucżyćielu / Które jeſt nawiękƺe przykazánie w Zakonie?
+A JEzus mu rzekł ; Będźieƺ miłował PAná Bogá twego / ze wƺyſtkiego ſercá twego / y ze wƺyſtkiey duƺe twojey / y ze wƺyſtkiey myśli twojey.
+To jeſt pierwƺe y nawiękƺe przykazánie.
 A wtóre podobne jeſt temuż : Będźieƺ miłował bliźniego twego / jáko ſámego śiebie.
-Ná tych dwu przykázániách wƺyſtek zakon y prorocy záwiſnęli.
+Ná tych dwu przykazániách wƺyſtek Zakon y Prorocy záwiſnęli.
 A gdy śię Fáryzeuƺowie zebráli / ſpytał ich JEzus /
-Mówiąc : Co śię wam zda o CHryſtuśie? Cżyim jeſt ſynem? Rzekli mu : Dawidowym.
-Y rzekł im : Jákoż tedy Dawid w duchu názywá go Pánem? mówiąc :
-Rzekł Pán Pánu memu : Siądź po práwicy mojey / áż położę nieprzyjáćioły twoje podnóżkiem nóg twojich.
-Ponieważ go tedy Dawid názywá Pánem / jákoż jeſt ſynem jego?
-A żáden mu nie mógł odpowiedźieć y ſłowá / y nie śmiał go nikt więcey od onego dniá pytáć.
+Mówiąc ; Co śię wam zda o CHryſtuśie? Cżyjim jeſt Synem? Rzekli mu ; Dawidowym.
+<i>Y</i> rzekł im ; Jákoż tedy Dawid w Duchu názywa go PAnem? mówiąc :
+Rzekł PAN PAnu memu / śiądź po práwicy mojey / áż położę nieprzyjaćioły twoje podnóżkiem nóg twojich.
+Ponieważ go tedy Dawid názywa PAnem / jákoż jeſt Synem jego?
+A żaden mu nie mógł odpowiedźieć <i>y</i> ſłowá : y nie śmiał go nikt więcey od onego dniá pytáć.


### PR DESCRIPTION
słowo "zmartwychwſtánie" w 1660 jest pisane osobno

Powtarza się zamiana:
słowa: wnijść, wynijść i ich odmiany w skanie wystęują bez "j" w środku wyrazu, np:
wnijść -> wniść
wynijść -> wyniść
(zamiany: "wnij*" -> "wni*" oraz "wynij*" -> "wyni*")