### PR TITLE
Mat.19.

### DIFF
--- a/1632/40-mat/19.txt
+++ b/1632/40-mat/19.txt
@@ -1,30 +1,30 @@
-Y ſtáło śię / gdy dokońcżył JEzus tych mów / odƺedł z Gálilei / á przyƺedł ná gránice Judzkie nád Jordán.
-Y ƺedł zá nim wielki lud / y uzdráwiał je tám.
-Tedy przyƺli do niego Fáryzeuƺowie / kuƺąc go y mówiąc mu : Godźili śię cżłowiekowi opuśćić żonę ſwoją dla káżdej przycżyny?
-A on odpowiádájąc rzekł im : Nie cżytáliśćie / iż ten / który ſtworzył ná pocżątku cżłowieká / mężcżyznę y niewiáſtę ucżynił je?
-Y rzekł : Dla tego opuśći cżłowiek ojcá y mátkę / á przyłącży śię do żony ſwojey / y będą dwoje jednem ćiáłem.
-A ták już nie ſą dwoje / ále jedno ćiáło ; co tedy Bóg złącżył / cżłowiek niecháj nie rozłącżá.
-Rzekli mu : Przecżże tedy Mojzeƺ rozkázał dáć liſt rozwodny y opuśćić ją?
-Rzekł im : Mojzeƺ dla zátwárdzeniá ſercá wáƺego dopuśćił wam / opuśćić żony wáƺe / lecż z pocżątku nie było ták.
-Ale ja powiádám wam : Iż ktobykolwiek opuśćił żonę ſwoję / ( oprócż dla wƺetecżeńſtwá / ) á inƺąby pojął / cudzołoży ; á ktoby opuƺcżoną pojął / cudzołoży.
-Rzekli mu ucżniowie jego : Jeſlić táká jeſt ſpráwá mężá z żoną / tedy nie jeſt dobrá / żenić śię.
-A on im rzekł : Nie wƺyſcy pojmują tey rzecży / ále tylko ći / którym to dáno.
-Abowiem ſą rzezáńcy / którzy śię ták z żywotá mátki národźili ; ſą też rzezáńcy / którzy od ludźi ſą urzezáni ; ſą też rzezáńcy / którzy śię ſámi urzezáli dla króleſtwá niebieſkiego. Kto może pojąć / niecháj pojmuje!
-Tedy mu przynoƺono dźiátki / áby ná nie ręce wkłádał y modlił śię ; ále ucżniowie gromili je.
-Lecż JEzus rzekł : Zániechájćie dźiátek / á nie zábrániájćie im / przychodźić do mnie ; ábowiem tákich jeſt króleſtwo niebieſkie.
+Y ſtáło śię gdy dokońcżył JEzus tych mów / odƺedł z Gálilejey / á przyƺedł ná gránice Judſkie nád Jordan.
+Y ƺedł zá nim wielki lud / y uzdrawiał je tám.
+Tedy przyƺli do niego Fáryzeuƺowie kuƺąc go / y mówiąc mu : Godźili śię cżłowiekowi opuśćić żonę ſwoję dla káżdey przycżyny?
+A on odpowiádájąc / rzekł im : Nie cżytáliśćie / iż ten który ſtworzył ná pocżątku <i>cżłowieká,</i> mężcżyznę y niewiáſtę ucżynił je?
+Y rzekł : Dla tego opuśći cżłowiek Ojcá y Mátkę / á przyłącży śię do żony ſwojey : y będą dwoje jednym ćiáłem.
+A ták już nie ſą dwoje / ále jedno ćiáło : Co tedy Bóg złącżył / cżłowiek niechaj nie rozłącża.
+Rzekli mu : Przecżże tedy Mojzeƺ rozkazał dáć liſt rozwodny / y opuśćić ją?
+Rzekł im : Mojzeƺ dla zátwárdzenia ſercá wáƺego dopuśćił wam opuśćić żony wáƺe : lecż z pocżątku nie było ták.
+Ale Ja powiádam wam : Iż ktobykolwiek opuśćił żonę ſwoję ( oprócż dla wƺetecżeńſtwá ) á inƺąby pojął / cudzołoży : á ktoby opuƺcżoną pojął / cudzołoży.
+Rzekli mu ucżniowie jego : Jeſlić táka jeſt ſpráwá mężá z żoną / tedy nie jeſt dobra żenić śię.
+A on im rzekł : Nie wƺyſcy pojmują tey rzecży / ále <i>tylko ći</i> którym to dano.
+Abowiem ſą rzezáńcy / którzy śię ták z żywotá mátki národźili : ſą też rzezáńcy / którzy od ludźi ſą urzezáni : ſą też rzezáńcy / którzy śię ſámi urzezáli dla króleſtwá niebieſkiego. Kto może pojąć / niechaj pojmuje!
+Tedy mu przynoƺono dźiatki áby ná nie ręce wkładał y modlił śię : ále ucżniowie gromili je.
+Lecż JEzus rzekł : Zániechajćie dźiatek / á nie zábraniajćie im przychodźić do mnie : ábowiem tákich jeſt króleſtwo niebieſkie.
 A włożywƺy ná nie ręce / poƺedł z támtąd.
-A oto / jeden przyſtąpiwƺy / rzekł mu : Náucżyćielu dobry! co dobrego mam cżynić ábym miał żywot wiecżny?
-Ale mu on rzekł : Przecż mię zowieƺ dobrym? nikt nie jeſt dobry / tylko jeden / to jeſt Bóg ; á jeſli chceƺ wnijść do żywotá / przeſtrzegáj przykázáń.
-Y rzekł mu : Których? A JEzus rzekł : Nie będźieƺ zábijał / nie będźieƺ cudzołożył / nie będźieƺ krádł / nie będźieƺ mówił fáłƺywego świádectwá ;
-Cżćij ojcá twego y mátkę / y miłowáć będźieƺ bliźniego ſwego / jáko śiebie ſámego.
-Rzekł mu młodźieniec : Tegom wƺyſtkiego przeſtrzegał od młodośći mojey ; cżegoż mi jeƺcże nie doſtáje?
-Rzekł mu JEzus : Jeſli chceƺ być doſkonáłym / idź / ſprzedáj májętnośći twoje / y rozdáj ubogim / á będźieƺ miał ſkárb w niebie / á przyƺedƺy / náśláduj mię.
-A gdy młodźieniec te ſłowá uſłyƺał / odƺedł ſmutny ; ábowiem wiele miał májętnośći.
-Tedy JEzus rzekł ucżniom ſwoim : Zápráwdę powiádám wam / że z trudnośćią bogáty wnijdźie do króleſtwá niebieſkiego.
-Y záśię powiádám wam : Że ſnádniej wielbłądowi przez ucho igielne przejść / niż bogátemu wnijść do króleſtwá Bożego.
-Co uſłyƺáwƺy ucżniowie jego / zdumieli śię bárzo / mówiąc : Któż tedy może być zbáwion?
-A JEzus wejrzáwƺy ná nie / rzekł im : U ludźić to nie można ; lecż u Bogá wƺyſtko jeſt możebne.
-Tedy odpowiádájąc Piotr / rzekł mu : Otośmy my opuśćili wƺyſtko / y poƺliśmy zá tobą ; cóż nam tedy zá to będźie?
-A JEzus rzekł im : Zápráwdę powiádám wam : Iż wy / którzyśćie mię náśládowáli w odrodzeniu / gdy uśiądźie Syn cżłowiecży ná ſtolicy chwały ſwojey / uśiądźiećie y wy ná dwunáſtu ſtolicách / ſądząc dwánaśćie pokoleń Izráelſkich.
-A káżdy / ktoby opuśćił domy / álbo bráći / álbo śioſtry / álbo ojcá / álbo mátkę / álbo żonę / álbo dźieći / álbo rolę / dla imienia mego / ſtokroć więcey weźmie / y żywot wiecżny odźiedźicży.
+A oto jeden przyſtąpiwƺy / rzekł mu : Náucżyćielu dobry / co dobrego mam cżynić ábym miał żywot wiecżny?
+Ale mu on rzekł : Przecż mię zowieƺ dobrym? nikt nie <i>jeſt</i> dobry / tylko jeden / <i>to jeſt</i> Bóg : á jeſli chceƺ wniść do żywotá / przeſtrzegaj przykazań.
+Y rzekł mu : Których? A JEzus rzekł : Nie będźieƺ zábijał : Nie będźieƺ cudzołożył : Nie będźieƺ kradł : Nie będźieƺ mówił fałƺywego świádectwá.
+Cżći Ojcá twego y Mátkę : y miłowáć będźieƺ bliźniego ſwego / jáko śiebie ſámego.
+Rzekł mu młodźieniec : Tegom wƺyſtkiego przeſtrzegał od młodośći mojey : cżegoż mi jeƺcże nie doſtawa?
+Rzekł mu JEzus : Jeſli chceƺ być doſkonáłym / idź / przedaj májętnośći twoje / y rozdaj ubogim ; á będźieƺ miał ſkarb w niebie : á przyƺedƺy / náśláduj mię.
+A gdy młodźieniec te ſłowá uſłyƺał / odƺedł ſmutny : ábowiem wiele miał májętnośći.
+Tedy JEzus rzekł ucżniom ſwojim : Záprawdę powiádam wam / że z trudnośćią bogáty wnidźie do króleſtwá niebieſkiego.
+Y záśię powiádam wam : Że ſnádniey wielbłądowi przez ucho igielne przejść / niż bogátemu wniść do króleſtwá Bożego.
+<i>Co</i> uſłyƺawƺy ucżniowie jego / zdumieli śię bárzo / mówiąc : Któż tedy może być zbáwion?
+A JEzus wejrzawƺy ná nie / rzekł im : U ludźić to nie można : lecż u Bogá wƺyſtko jeſt możno.
+Tedy odpowiádájąc Piotr / rzekł mu : Otoſmy my opuśćili wƺyſtko / y poƺliſmy zá tobą / cóż nam tedy <i>zá to</i> będźie?
+A JEzus im rzekł ; Záprawdę powiádam wam / iż wy którzyśćie mię náśládowáli w odrodzeniu / gdy uśiędźie Syn cżłowiecży ná ſtolicy chwały ſwojey / uśiądźiećie y wy ná dwunaſtu ſtolicách / ſądząc dwánaśćie pokolenia Izráelſkie.
+A káżdy ktoby opuśćił domy álbo bráćią / álbo śioſtry / álbo ojcá / álbo mátkę / álbo żonę / álbo dźieći / álbo role dla Imienia mego / ſto kroć więcey weźmie / y żywot wiecżny odźiedźicży.
 A wiele pierwƺych będą oſtátnimi / á oſtátnich pierwƺymi.


### PR DESCRIPTION
w.29. 1606 ma "ojca" z dużej litery; 1660 i 1606 mają "abo" zamiast "albo"