### PR TITLE
Mat.16.

### DIFF
--- a/1632/40-mat/16.txt
+++ b/1632/40-mat/16.txt
@@ -1,28 +1,28 @@
-A przyſtąpiwƺy Fáryzeuƺowie y Sáduceuƺowie / kuƺąc / prośili go áby im známię z niebá ukázał.
+A przyſtąpiwƺy Fáryzeuƺowie y Sáduceuƺowie / kuƺąc / prośili go áby im známię z niebá ukazał.
 A on odpowiádájąc / rzekł im : Gdy bywa wiecżór / mówićie ; Pogodá <i>będźie,</i> bo śię niebo cżerwieni.
 A ráno : Dźiś <i>będźie</i> niepogodá ; Abowiem śię niebo pochmurne cżerwieni. Obłudnicy! Poſtáwę niebá rozſądźić umiećie / á známion tych cżáſów nie możećie.
-Rodzáj zły y cudzołożny / známieniá ƺuká /  ále mu známię nie będźie / dáno tylko ono známię Jonáƺá Proroká. Y opuśćiwƺy je / odƺedł.
+Rodzaj zły y cudzołożny / známienia ƺuka / ále mu známię nie będźie / dano tylko ono známię Jonaƺá Proroká. Y opuśćiwƺy je / odƺedł.
 A gdy śię przepráwili ucżniowie jego ná drugą ſtronę <i>morzá,</i> zápámiętáli wźiąć chlebá.
 Y rzekł im JEzus ; Pátrzćie / á ſtrzeżćie śię kwáſu Fáryzeuƺów y Sáduceuƺów.
-A oni rozmáwiáli miedzy ſobą / mówiąc : Nie wźięliśmy chlebá.
-Co obácżywƺy JEzus / rzekł im : O cżemże rozmáwiáćie miedzy ſobą / o máłowierni! Żeśćie chlebá nie wźięli?
-Jeƺcżeż nie rozumiećie áni pámiętáćie onych pięćiu chlebów / á onych pięćiu tyśięcy <i>ludźi</i> : y jákośćie wiele koƺów zebráli?
-Ani onych śiedmiu chlebów / y cżterech tyśięcy <i>ludźi</i> : á jákośćie wiele koƺów názbieráli?
+A oni rozmawiáli miedzy ſobą / mówiąc : Nie wźięliſmy chlebá.
+Co obacżywƺy JEzus / rzekł im : O cżymże rozmawiaćie miedzy ſobą / o máło wierni! Żeśćie chlebá nie wźięli?
+Jeƺcżeż nie rozumiećie áni pámiętaćie onych piąći chlebów / á onych piąći tyśięcy <i>ludźi</i> : y jákośćie wiele koƺów zebráli?
+Ani onych śiedmi chlebów / <i>y</i> cżterech tyśięcy <i>ludźi</i> : á jákośćie wiele koƺów názbieráli?
 Jákoż nie rozumiećie / żem wam nie o chlebie powiedźiał / <i>mówiąc</i> : Abyśćie śię ſtrzegli kwáſu Fáryzeuƺów y Sáduceuƺów?
 Tedy zrozumieli / że nie mówił áby śię ſtrzegli kwáſu chlebá ; ále náuki Fáryzeuƺów y Sáduceuƺów.
-A gdy przyƺedł JEzus w ſtrony Cezáryi Filippowej / pytał ucżniów ſwojich / mówiąc ; Kimże mię powiádáją być ludźie Syná cżłowiecżego?
-A oni rzekli ; Jedni Jánem Chrzćićielem ; á drudzy Elijáƺem ; inśi też Jeremijáƺem / álbo jednym z Proroków.
-Y rzekł im ; A wy kim mię być powiádáćie?
-A odpowiádájąc Szymon Piotr / rzekł ; Tyś jeſt CHryſtus on Syn Bogá żywego.
-Tedy odpowiádájąc JEzus / rzekł mu ; Błogoſłáwionyś Szymonie / ſynu Jonáƺów : bo <i>tego</i> ćiáło y krew nie objáwiła tobie / ále Oćiec mój który jeſt w niebieśiech.
-A Jáć też powiádám / żeś ty jeſt Piotr : á ná tey opoce zbuduję Kośćiół mój / á bramy piekielne nie przemogą go.
-Y tobie dam klucże króleſtwá niebieſkiego : á cokolwiek zwiążeƺ ná źiemi / będźie związáno y w niebieśiech / á cokolwiek rozwiążeƺ ná źiemi / będźie rozwiązáno y w niebieśiech.
-Tedy przykázał ucżniom ſwoim / áby nikomu nie powiádáli że on jeſt JEzus CHryſtus.
-Y odtąd pocżął JEzus pokázywáć ucżniom ſwoim / iż muśi odejść do Jeruzálemu / y wiele ćierpieć od ſtárƺych y od przedniejƺych Kápłanów / y Náucżonych w Piśmie ; á być zábitym / y trzećiego dniá zmartwychwſtáć.
-A wźiąwƺy go Piotr <i>ná ſtronę,</i> pocżął go ſtrofowáć / mówiąc ; Zmiłuj śię ſám nád ſobą Pánie ; nie przydźie to ná ćię.
+A gdy przyƺedł JEzus w ſtrony Cezáryey Filippowey / pytał ucżniów ſwojich / mówiąc ; Kimże mię powiádáją być ludźie Syná cżłowiecżego?
+A oni rzekli ; Jedni Janem Chrzćićielem ; á drudzy Eliaƺem ; inƺy też Jeremiaƺem / álbo jednym z Proroków.
+<i>Y</i> rzekł im ; A wy kim mię być powiádaćie?
+A odpowiádájąc Symon Piotr / rzekł ; Tyś jeſt CHryſtus on Syn Bogá żywego.
+Tedy odpowiádájąc JEzus / rzekł mu ; Błogoſłáwionyś Symonie / Synu Jonaƺów : bo <i>tego</i> ćiáło y krew nie objáwiłá tobie / ále Oćiec mój który jeſt w niebieśiech.
+A Jać też powiádam / żeś ty jeſt Piotr : á ná tey opoce zbuduję Kośćiół mój / á bramy piekielne nie przemogą go.
+Y tobie dam klucże króleſtwá niebieſkiego : á cokolwiek zwiążeƺ ná źiemi / będźie związano y w niebieśiech / á cokolwiek rozwiążeƺ ná źiemi / będźie rozwiązano <i>y</i> w niebieśiech.
+Tedy przykazał ucżniom ſwojim / áby nikomu nie powiádáli że on jeſt JEzus CHryſtus.
+Y od tąd pocżął JEzus pokázowáć ucżniom ſwojim / iż muśi odejść do Jeruzalem / y wiele ćierpieć od ſtárƺych y od przedniejƺych Kápłanów / y Náucżonych w piśmie ; á być zábitym / y trzećiego dniá zmartwychwſtáć.
+A wźiąwƺy go Piotr <i>ná ſtronę,</i> pocżął go ſtrofowáć / mówiąc ; Zmiłuj śię ſam nád ſobą PAnie ; nie przydźie to ná ćię.
 A on obróćiwƺy śię / rzekł Piotrowi ; Idź odemnie Szátánie / jeſteś mi zgorƺeniem : ábowiem nie pojmujeƺ tego co jeſt Bożego / ále co jeſt ludzkiego.
-Tedy rzekł JEzus do ucżniów ſwojich ; Jeſli kto chce iść zá mną / niechájże ſámego śiebie záprzy / á weźmie krzyż ſwój / y náśláduje mię.
-Bo ktoby chćiał duƺę ſwoję záchowáć / ſtráći ją : á ktoby ſtráćił duƺę ſwoję dla mnie / znájdźie ją.
-Abowiem / cóż pomoże cżłowiekowi / choćby wƺyſtek świát pozyſkał / á ná duƺy ſwojey ƺkodował? álbo co zá zámiánę da cżłowiek zá duƺę ſwoję?
-Abowiem Syn cżłowiecży przydźie w chwále Ojcá ſwego z Anioły ſwoimi : á tedy oddá káżdemu według ucżynków jego.
-Zápráwdę powiádám wam / są niektórzy z tych co tu ſtoją / którzy nie ukuƺą śmierći / áżby ujrzeli Syná cżłowiecżego idącego w Króleſtwie ſwojim.
+Tedy rzekł JEzus do ucżniów ſwojich ; Jeſli kto chce iść zá mną / niechajże ſámego śiebie záprzy / á weźmie krzyż ſwój / y náśláduje mię.
+Bo ktoby chćiał duƺę ſwoję záchowáć / ſtráći ją : á ktoby ſtráćił duƺę ſwoję dla mnie / znajdźie ją.
+Abowiem / cóż pomoże cżłowiekowi / choćby wƺyſtek świát pozyſkał / á ná duƺy ſwojey ƺkodował? álbo co zá zamiánę da cżłowiek zá duƺę ſwoję.
+Abowiem Syn cżłowiecży przydźie w chwale Ojcá ſwego z Anjoły ſwojimi : á tedy odda káżdemu według ucżynków jego.
+Záprawdę powiádam wam / ſą niektórzy z tych co tu ſtoją / którzy nie ukuƺą śmierći / áżby ujrzeli Syná cżłowiecżego idącego w Króleſtwie ſwojim.


### PR DESCRIPTION
w.8. KJV nie ma kursywy dla drugiego "o"