### PR TITLE
Objaw.16,21.

### DIFF
--- a/1632/66-apo/16.txt
+++ b/1632/66-apo/16.txt
@@ -18,4 +18,4 @@ Tedy wylał śiódmy Anjoł cżáƺę ſwoję ná powietrze : y wyƺedł głos w
 Y ſtáły śię głoſy y gromy / y łyſkáwice ; y ſtáło śię wielkie trzęśienie źiemie / jákiego nigdy nie było jáko ſą ludźie ná źiemi / trzęśienia źiemie ták wielkiego.
 Y ſtáło śię ono miáſto wielkie ná trzy częśći rozerwáne : Y miáſtá narodów upádły ; y Bábilon on wielki przyƺedł ná pámięć przed oblicżem Bożym / áby mu dał kielich winá zápálcżywośći gniewu ſwojego.
 Y wƺyſtkie wyſpy ućiekły / y góry nie ſą ználeźione.
-Y wielki grad jáko cetnarowy ſpadł z niebá ná ludźie : y bluźnili ludźie Bogá / dla plági grádu ; iż plagá jego byłá bárzo wielka.
+Y wielki grad jáko cetnarowy zpadł z niebá ná ludźie : y bluźnili ludźie Bogá / dla plági grádu ; iż plagá jego byłá bárzo wielka.


### PR DESCRIPTION
1660 poprawia.
Przejrzałem wystąpienia słowa "ſpádł" dla 1632 i 1660 i nie ma jednolitej pisowni dla obu skanów, znalazłem że dla 2 wystąpień 1660 poprawia na "zpadł"