### PR TITLE
Mat.9.

### DIFF
--- a/1632/40-mat/09.txt
+++ b/1632/40-mat/09.txt
@@ -2,7 +2,7 @@ Tedy wſtąpiwƺy w łódź / przewiózł śię / y przyƺedł do miáſtá ſwe
 A oto przynieśli mu powietrzem ruƺonego ná łożu leżącego. A widząc JEzus wiárę ich / rzekł powietrzem ruƺonemu ; Ufaj ſynu / odpuƺcżone ſą tobie grzechy twoje.
 A oto niektórzy z Náucżonych w piśmie mówili ſámi w ſobie ; Ten bluźni.
 A widząc JEzus myśli ich / rzekł ; Przecżże wy myślićie złe rzecży w ſercách wáƺych?
-Abowiem / cóż łátwiey rzec? Odpuƺcżone ſą tobie grzechy : Cżyli rzec? Wſtań / á chodź.
+Abowiē / cóż łátwiey rzec? Odpuƺcżone ſą tobie grzechy : Cżyli rzec? Wſtań / á chodź.
 Ale ábyśćie wiedźieli / iż ma moc Syn cżłowiecży ná źiemi odpuƺcżáć grzechy / tedy rzekł powietrzem ruƺonemu ; Wſtawƺy / weźmi łoże twoje / á idź do domu twego.
 Tedy wſtawƺy / poƺedł do domu ſwego.
 Co ujrzawƺy lud / dźiwował śię / y chwalił Bogá / który dał táką moc ludźiom.

--- a/1632/40-mat/09.txt
+++ b/1632/40-mat/09.txt
@@ -1,38 +1,38 @@
 Tedy wſtąpiwƺy w łódź / przewiózł śię / y przyƺedł do miáſtá ſwego.
-A oto przynieśli mu powietrzem ruƺonego ná łożu leżącego. A widząc JEzus wiárę ich / rzekł powietrzem ruƺonemu ; Ufáj ſynu / odpuƺcżone ſą tobie grzechy twoje.
-A oto niektórzy z Náucżonych w Piśmie mówili ſámi w ſobie ; Ten bluźni.
+A oto przynieśli mu powietrzem ruƺonego ná łożu leżącego. A widząc JEzus wiárę ich / rzekł powietrzem ruƺonemu ; Ufaj ſynu / odpuƺcżone ſą tobie grzechy twoje.
+A oto niektórzy z Náucżonych w piśmie mówili ſámi w ſobie ; Ten bluźni.
 A widząc JEzus myśli ich / rzekł ; Przecżże wy myślićie złe rzecży w ſercách wáƺych?
-Abowie / cóż łátwiej rzec? Odpuƺcżone ſą tobie grzechy : Cżyli rzec? Wſtáń / á chodź?
-Ale ábyśćie wiedźieli / iż ma moc Syn cżłowiecży ná źiemi odpuƺcżáć grzechy / tedy rzekł powietrzem ruƺonemu ; Wſtáwƺy / weźmij łoże twoje / á idź do domu twego.
-Tedy wſtáwƺy / poƺedł do domu ſwego.
-Co ujrzáwƺy lud / dźiwował śię / y chwálił Bogá / który dał táką moc ludźiom.
-A odchodząc z támtąd JEzus / ujrzał cżłowieká śiedzącego ná cle / którego zwano Máteuƺ / y rzekł mu : Pójdź zá mną. Tedy wſtáwƺy / ƺedł zá nim.
+Abowiem / cóż łátwiey rzec? Odpuƺcżone ſą tobie grzechy : Cżyli rzec? Wſtań / á chodź.
+Ale ábyśćie wiedźieli / iż ma moc Syn cżłowiecży ná źiemi odpuƺcżáć grzechy / tedy rzekł powietrzem ruƺonemu ; Wſtawƺy / weźmi łoże twoje / á idź do domu twego.
+Tedy wſtawƺy / poƺedł do domu ſwego.
+Co ujrzawƺy lud / dźiwował śię / y chwalił Bogá / który dał táką moc ludźiom.
+A odchodząc z támtąd JEzus / ujrzał cżłowieká śiedzącego ná cle / którego zwano Mátteuƺ / y rzekł mu : Pódź zá mną. Tedy wſtawƺy / ƺedł zá nim.
 Y ſtáło śię / gdy JEzus śiedźiał zá ſtołem w domu <i>jego,</i> że oto wiele celników y grzeƺników przyƺedƺy / uśiedli z JEzuſem / y z ucżniámi jego.
-Co widząc Fáryzeuƺowie / rzekli ucżniom jego ; Przecżże z celnikámi y grzeƺnikámi je Náucżyćiel wáƺ?
-A JEzus uſłyƺáwƺy <i>to,</i> rzekł im ; Nie potrzebująć zdrowi lekárzá ; ále ći co śię źle máją.
-Owƺem idźćie / á náucżćie śię co to jeſt ; Miłośierdźiá chcę / á nie ofiáry ; bom nie przyƺedł wzywáć ſpráwiedliwych / ále grzeƺnych do pokuty.
-Tedy przyƺli do niego ucżniowie Jánowi / mówiąc ; Przecż my / y Fáryzeuƺowie cżęſto pośćimy / á ucżniowie twoi nie poƺcżą?
-Y rzekł im JEzus ; Izali śię mogą ſynowie łożnicy máłżeńſkiej ſmęćić póki z nimi jeſt oblubieniec? Ale przyjdą dni / gdy od nich będźie oblubieniec odjęty ; á tedy pośćić będą.
-A żáden nie wpráwuje łáty ſukná nowego w ƺátę wiotchą : ábowiem ono záłátánie ujmuje nieco od ƺáty / y ſtáwá śię gorƺe rozdárćie.
-Ani leją winá młodego w ſtáre ſtátki ; bo inácżey pukáją śię ſtátki : á wino wyćieká / y ſtátki śię pſują : ále młode wino leją w nowe ſtátki / y oboje bywáją záchowáne.
-To gdy on do nich mówił / oto niektóry Przełożony bóżnicy przyƺedƺy pokłonił mu śię / mówiąc ; Córká mojá dopiero ſkonáłá ; ále pójdź / á włóż ná nię rękę twoję / á ożyje.
-Tedy wſtáwƺy JEzus / ƺedł zá nim / y ucżniowie jego.
-( A oto niewiáſtá / która płynienie krwi ode dwunáſtu lat ćierpiáłá / przyſtąpiwƺy z tyłu / dotknęłá śię podołká ƺáty jego.
-Bo rzekłá ſámá w ſobie ; Jeſli śię tylko dotknę ƺáty jego / będę uzdrowioná.
-Ale JEzus obróćiwƺy śię y ujrzáwƺy ją / rzekł ; Ufáj córko : wiárá twojá ćiebie uzdrowiłá. Y uzdrowioná byłá niewiáſtá od oney godźiny. )
+Co widząc Fáryzeuƺowie / rzekli ucżniom jego ; Przecżże z Celnikámi y grzeƺnikámi je Náucżyćiel wáƺ?
+A Jezus uſłyƺawƺy <i>to,</i> rzekł im ; Nie potrzebująć zdrowi lekárzá ; ále ći / co śię źle máją.
+Owƺem idźćie / á náucżćie śię co <i>to</i> jeſt ; Miłośierdźia chcę / á nie ofiáry. Bom nie przyƺedł wzywáć ſpráwiedliwych ále grzeƺnych do pokuty.
+Tedy przyƺli do niego ucżniowie Janowi / mówiąc ; Przecż my / y Fáryzeuƺowie cżęſto pośćimy / á ucżniowie twoji nie poƺcżą?
+Y rzekł im JEzus ; Izali śię mogą ſynowie łożnice małżeńſkiey ſmęćić póki z nimi jeſt oblubieniec? Ale przydą dni / gdy od nich będźie oblubieniec odjęty ; á tedy pośćić będą.
+A żaden nie wpráwuje łáty ſukná nowego w ƺátę wiotchą : ábowiem ono záłatánie ujmuje nieco od ƺáty / y ſtawa śię gorƺe rozdárćie.
+Ani leją winá młodego w ſtáre ſtátki ; bo inácżey pukáją śię ſtátki : á wino wyćieka / y ſtátki śię pſują : ále młode wino leją w nowe ſtátki / y oboje bywáją záchowáne.
+To gdy on do nich mówił / oto niektóry Przełożony bóżnice / przyƺedƺy pokłonił mu śię / mówiąc ; Córká mojá dopiero ſkonáłá ; ále pódź / á włóż ná nię rękę twoję / á ożyje.
+Tedy wſtawƺy JEzus / ƺedł zá nim / y ucżniowie jego.
+( A oto niewiáſtá która płynienie krwie ode dwunaſtu lat ćierpiáłá / przyſtąpiwƺy z tyłu / dotknęłá śię podołká ƺáty jego.
+Bo rzekłá ſámá w ſobie ; Jeſli śię tylko dotknę ƺáty jego / będę uzdrowiona.
+Ale JEzus obróćiwƺy śię y ujrzawƺy ją / rzekł ; Ufaj córko : wiárá twojá ćiebie uzdrowiłá. Y uzdrowiona byłá niewiáſtá od oney godźiny. )
 A gdy przyƺedł JEzus w dom Przełożonego / y ujrzał piƺcżki y lud zgiełk cżyniący /
-Rzekł im ; Uſtąpćie : ábowiem dźiewecżká nie umárłá / ále śpi. Y náśmiewáli śię z niego.
+Rzekł im ; Uſtąpćie : Abowiem dźiewecżká nie umárłá / ále ſpi. Y náśmiewáli śię z niego.
 Ale gdy wygnány był on lud / wƺedƺy ujął ją zá rękę jey ; y wſtáłá dźiewecżká.
-Y rozeƺłá śię tá wieść po wƺyſtkiej źiemi.
+Y rozeƺłá śię tá wieść po wƺyſtkiey źiemi.
 A gdy JEzus odchodźił z támtąd / ƺli zá nim dwá ślepi / wołájąc y mówiąc ; Synu Dawidów / Zmiłuj śię nád námi!
-A gdy on wƺedł do domu / przyƺli do niego ślepi / y rzekł im JEzus ; Wierzyćież iż to mogę ucżynić? Rzekli mu ; Owƺem PAnie!
-Tedy śię dotknął ocżu ich / mówiąc ; Według wiáry wáƺej niecháj śię wam ſtánie.
-Y otworzyły śię ocży ich : y przygroźił im ſrodze JEzus / mówiąc ; Pátrzćież áby nikt o tym nie wiedźiał.
-Lecż oni wyƺedƺy / rozſłáwili go po wƺyſtkiej oney źiemi.
-A gdy oni wychodźili / oto przywiedli mu cżłowieká niemego / opętánego od Dyjábłá.
-A gdy był wygnány on dyjábeł / przemówił niemy ; y dźiwował śię lud / mówiąc ; Nigdy śię táká rzecż nie pokázáłá w Izráelu.
-Ale Fáryzeuƺowie mówili ; Przez Kśiążę Dyjábelſkie wygánia dyjábły.
-Y obchodźił JEzus wƺyſtkie miáſtá y miáſtecżká / náucżájąc w bóżnicách ich / y káżąc Ewángieliją króleſtwá / á uzdráwiájąc wƺelką chorobę / y wƺelką niemoc miedzy ludem.
-A widząc on lud / użálił śię go / iż był ſtrudzony y rozproƺony jáko owce niemájące páſterzá.
-Tedy rzekł ucżniom ſwoim ; Żniwoć wpráwdźie wielkie / ále robotników máło.
+A gdy on wƺedł do domu / przyƺli do niego ślepi / y rzekł im JEzus ; Wierzyćież iż to mogę ucżynić? Rzekli mu ; Owƺem PAnie.
+Tedy śię dotknął ocżu ich / mówiąc ; Według wiáry wáƺey niechaj śię wam ſtánie.
+Y otworzyły śię ocży ich : y przygroźił im ſrodze JEzus / mówiąc ; Pátrzćież áby nikt <i>o tym<i/> nie wiedźiał.
+Lecż oni wyƺedƺy / rozſławili go po wƺyſtkiey oney źiemi.
+A gdy oni wychodźili / oto przywiedli mu cżłowieká niemego / opętánego od Dyabłá.
+A gdy był wygnány on dyabeł / przemówił niemy : y dźiwował śię lud / mówiąc ; Nigdy śię táka rzecż nie pokazáłá w Izráelu.
+Ale Fáryzeuƺowie mówili ; Przez Kśiążę Dyabelſkie wygania dyabły.
+Y obchodźił JEzus wƺyſtkie miáſtá y miáſtecżká / náucżájąc w bóżnicách ich / y każąc Ewángelią króleſtwá / á uzdrawiájąc wƺelką chorobę / y wƺelką niemoc miedzy ludem.
+A widząc on lud / użalił śię go / iż był ztrudzony y rozproƺony jáko owce nie májące páſterzá.
+Tedy rzekł ucżniom ſwojim ; Żniwoć wprawdźie wielkie / ále robotników máło.
 Prośćie tedy PAná żniwá / áby wypchnął robotniki ná żniwo ſwoje.


### PR DESCRIPTION
w.12. 1632 i 1660 mają "Jezus" ale jest to niejednolite z resztą wystąpień - "JEzus"
w.33. 1606 ma osobno "nie pokázáłá"