### PR TITLE
Mat.11.

### DIFF
--- a/1632/40-mat/11.txt
+++ b/1632/40-mat/11.txt
@@ -1,30 +1,30 @@
-Y ſtáło śię / gdy JEzus przeſtał rozkázowáć dwienáſśćie ucżniom ſwoim / poƺedł z onąd áby ucżył / y kázał w miáſtách ich.
-A Ján uſłyƺáwƺy w więźieniu o ucżynkách CHryſtuſowych / poſłáwƺy dwu z ucżniów ſwojich /
-Rzekł mu ; Tyżeś jeſt on który ma przyść / cżyli inƺego cżekáć mamy?
-A odpowiádájąc JEzus / rzekł im ; Szedƺy / oznájmijćie Jánowi co ſłyƺyćie / y widźićie.
-Ślepi widzą / á chromi chodzą / trędowáći biorą ocżyƺcżenie / á głuszy ſłyƺą / umárli zmartwychwſtáją y ubogim Ewángielijá opowiádáná bywa.
+Y ſtáło śię / gdy JEzus przeſtał rozkázowáć dwiemánaśćie ucżniom ſwojim / poƺedł z onąd áby ucżył / y kazał w miáſtách ich.
+A Jan uſłyƺawƺy w więźieniu o ucżynkách CHryſtuſowych / poſławƺy dwu z ucżniów ſwojich /
+Rzekł mu ; Tyżeś jeſt on który ma przyść / cżyli inƺego cżekáć mámy?
+A odpowiádájąc JEzus / rzekł im ; Szedƺy / oznájmićie Janowi co ſłyƺyćie / y widźićie.
+Ślepi widzą / á chromi chodzą / trędowáći biorą ocżyśćienie / á głuƺy ſłyƺą / umárli zmartwychwſtáją y ubogim Ewángelia opowiádána bywa.
 A błogoſłáwiony jeſt który śię nie zgorƺy ze mnie.
-A gdy oni odeƺli / pocżął JEzus mówić do ludu o Jánie ; Cośćie wyƺli ná puƺcżą widźieć? <i>Izali</i> trzćinę chwiejącą śię od wiátru?
-Ale cośćie wyƺli widźieć? Izali cżłowieká w miękkie ƺáty oblecżonego? oto którzy miękkie <i>ƺáty</i> noƺą / w domách królewſkich ſą.
-Ale cośćie wyƺli widźieć? Izali proroká? zájiſte powiádám wam / y więcey niż proroká.
-Boć ten jeſt o którym nápiſano ; Oto ja poſyłám Aniołá mego przed oblicżem twojim / który zgotuje drogę twoję przed tobą.
-Zápráwdę powiádám wam ; Nie powſtał z tych którzy śię z niewiáſt rodzą więkƺy / nád Jáná Chrzćićielá : Ale który jeſt nájmniejƺym w króleſtwie niebieſkim / więkƺy jeſt niżeli on.
-A ode dni Jáná Chrzćićielá áż dotąd / króleſtwo niebieſkie gwáłt ćierpi ; á gwáłtownicy porywáją je.
-Bo wƺyſcy prorocy y zakon / áż do Jáná prorokowáli.
-A jeſli to chcećie przyjąć ; onći jeſt Elijáƺ / który miał przyść.
-Kto ma uƺy ku ſłuchániu / niecháj ſłuchá.
-Ale komuż przypodobám ten národ? podobny jeſt dźiátkom które śiedzą ná rynkách / y wołáją ná towárzyƺe ſwoje /
-Y mówią ; Gráliſmy wam ná piƺcżáłce / á nie táńcowáliśćie : śpiewáliſmy pieśni żáłobne / á nie płákáliśćie.
-Abowiem przyƺedł Ján áni jedząc áni pijąc / á mówią ; Iż dyjábelſtwo ma.
-Przyƺedł Syn cżłowiecży jedząc y pijąc / á mówią ; Oto cżłowiek obżercá y pijánicá winá / przyjáćiel celników y grzeƺników. Y uſpráwiedliwioná jeſt mądrość od ſynów ſwojich.
-Tedy pocżął przymáwiáć miáſtom / w których śię nájwięcey dźiáło cudów jego / że nie pokutowáły / <i>mówiąc</i> ;
-Biádá tobie Chorázynie / biádá tobie Betſáido! bo gdyby śię były w Tyrze y w Sydonie te cudá ſtáły / które śię w was ſtáły / dáwnoby były w worze y w popiele pokutowáły.
-Wƺákże powiádám wam ; Lżey będźie Tyrowi y Sydonowi w dźień ſądny / niżeli wam.
-A ty Kápernáum / któreś áż do niebá wywyżƺone / áż do piekłá ſtrącone będźieƺ : Bo gdyby śię były w Sodomie te cudá dźiáły / które śię dźiáły w tobie / zoſtáłáby byłá áż do dniá dźiśiejƺego.
-Náwet powiádám wam ; Iż lżey będźie źiemi Sodomſkiej w dźień ſądny / niżeli tobie.
-W on cżás odpowiádájąc JEzus / rzekł ; Wyſłáwiám ćię Ojcże / Pánie niebá y źiemie / żeś te rzecży zákrył przed mądrymi y roztropnymi / á objáwiłeś je niemowlątkom.
-Zápráwdę Ojcże / ták śię upodobáło tobie.
-Wƺyſtkie rzecży dáne mi ſą od Ojcá mego / y nikt nie zná Syná / tylko Oćiec / áni Ojcá kto zná / tylko Syn : á komuby chćiał Syn objáwić.
-Pójdźćie do mnie wƺyſcy którzyśćie ſprácowáni y obćiążeni / á Ja wam ſpráwię odpocżnienie.
-Weźmijćie járzmo moje ná śię / á ucżćie śię ode mnie żem Ja ćichy y pokornego ſercá : á znájdźiećie odpocżnienie duƺom wáƺym.
-Abowiem járzmo moje wdźięcżne jeſt / á brzemię moje lekkie jeſt.
+A gdy oni odeƺli / pocżął JEzus mówić do ludu o Janie ; Cośćie wyƺli ná puƺcżą widźieć? <i>Izali</i> trzćinę chwiejącą śię od wiátru?
+Ale cośćie wyƺli widźieć? <i>Izali</i> cżłowieká w miękkie ƺáty oblecżonego? Oto którzy miękkie <i>ƺáty</i> noƺą / w domách królewſkich ſą.
+Ale cośćie wyƺli widźieć? <i>Izali</i> Proroká? zájiſte powiádam wam / y więcey niż Proroká.
+Boć ten jeſt o którym nápiſano ; Oto Ja poſyłam Anjołá mego przed oblicżem twojim / który zgotuje drogę twoję przed tobą.
+Záprawdę powiádam wam ; Nie powſtał z tych którzy śię z niewiaſt rodzą więkƺy / nád Janá Chrzćićielá : Ale który jeſt namniejƺym w króleſtwie niebieſkim / więkƺy jeſt niżeli on.
+A ode dni Janá Chrzćićielá áż do tąd / króleſtwo niebieſkie gwałt ćierpi ; á gwałtownicy porywáją je.
+Bo wƺyſcy Prorocy y Zakon / áż do Janá prorokowáli.
+A jeſli <i>to</i> chcećie przyjąć ; onći jeſt Eliaƺ / który miał przyść.
+Kto ma uƺy ku ſłuchániu / niechaj ſłucha.
+Ale komuż przypodobam ten naród? Podobny jeſt dźiatkom które śiedzą ná rynkách / y wołáją ná towárzyƺe ſwoje /
+Y mówią ; Gráliſmy wam ná piƺcżałce / á nie táńcowáliśćie : śpiewáliſmy pieśni żałobne / á nie płákáliśćie.
+Abowiem przyƺedł Jan áni jedząc áni pijąc / á mówią ; Iż dyabelſtwo ma.
+Przyƺedł Syn cżłowiecży jedząc y pijąc / á mówią ; Oto cżłowiek obżercá y pijánicá winá / przyjaćiel Celników y grzeƺników. Y uſpráwiedliwiona jeſt mądrość od ſynów ſwojich.
+Tedy pocżął przymawiáć miáſtom / w których śię nawięcey dźiało cudów jego / że nie pokutowáły / <i>mówiąc</i> ;
+Biádá tobie Chorázynie / biádá tobie Betſájdo! Bo gdyby śię były w Tyrze y w Sydonie te cudá ſtáły / które śię w was ſtáły / dawnoby były w worze y w popiele pokutowáły.
+Wƺákże powiádam wam ; Lżey będźie Tyrowi y Sydonowi w dźień ſądny / niżeli wam.
+A ty Kápernáum / któreś áż do niebá wywyżƺone / áż do piekłá ztrącone będźieƺ : Bo gdyby śię były w Sodomie te cudá dźiały / które śię dźiały w tobie / zoſtáłáby byłá áż do <i>dniá</i> dźiśiejƺego.
+Náwet powiádam wam ; Iż lżey będźie źiemi Sodomſkiey w dźień ſądny / niżeli tobie.
+W on cżás odpowiádájąc JEzus / rzekł ; Wyſławiam ćię Ojcże / PAnie niebá y źiemie / żeś te rzecży zákrył przed mądrymi y roſtropnymi / á objáwiłeś je niemowiątkom.
+Záprawdę Ojcże / ták śię upodobáło tobie.
+Wƺyſtkie rzecży dáne mi ſą od Ojcá mego / y nikt nie zna Syná / tylko Oćiec : áni Ojcá kto zna / tylko Syn : á komuby chćiał Syn objáwić.
+Pódźćie do mnie wƺyſcy którzyśćie zprácowáni y obćiążeni / á Ja wam ſpráwię odpocżynienie.
+Weźmićie járzmo moje ná śię / á ucżćie śię ode mnie żem Ja ćichy y pokornego ſercá : á znajdźiećie odpocżynienie duƺom wáƺym.
+Abowiem járzmo moje wdźięcżne jeſt : á brzemię moje lekkie jeſt.

--- a/1632/40-mat/11.txt
+++ b/1632/40-mat/11.txt
@@ -26,5 +26,5 @@ W on cżás odpowiádájąc JEzus / rzekł ; Wyſławiam ćię Ojcże / PAnie ni
 Záprawdę Ojcże / ták śię upodobáło tobie.
 Wƺyſtkie rzecży dáne mi ſą od Ojcá mego / y nikt nie zna Syná / tylko Oćiec : áni Ojcá kto zna / tylko Syn : á komuby chćiał Syn objáwić.
 Pódźćie do mnie wƺyſcy którzyśćie zprácowáni y obćiążeni / á Ja wam ſpráwię odpocżynienie.
-Weźmićie járzmo moje ná śię / á ucżćie śię ode mnie żem Ja ćichy y pokornego ſercá : á znajdźiećie odpocżynienie duƺom wáƺym.
+Weźmićie járzmo moje ná śię / á ucżćie śię ode mnie żem Ja ćichy y pokornego ſercá : á znajdźiećie odpocżynienie duƺam wáƺym.
 Abowiem járzmo moje wdźięcżne jeſt : á brzemię moje lekkie jeſt.


### PR DESCRIPTION
w.29. 1632 i 1660 "duƺam", a w 1606 "duƺom". Mimo to inne wystąpienie w 1632 konsekwentnie "duƺam". 