### PR TITLE
Mat.12.

### DIFF
--- a/1632/40-mat/12.txt
+++ b/1632/40-mat/12.txt
@@ -1,50 +1,50 @@
-W on cżás / ƺedł JEzus w ſábát przez zbożá á ucżniowie jego łáknęli / y pocżęli rwáć kłoſy y jeść.
-A ujrzáwƺy to Fáryzeuƺowie / rzekli mu ; Oto ucżniowie twoi cżynią / cżego śię nie godźi cżynić w Sábbát.
-A on im rzekł ; Izáśćie nie cżytáli co ucżynił Dawid gdy łáknął / on y ći którzy z nim byli?
-Jáko wƺedł do domu Bożego / y chleby pokłádne jádł / których mu śię nie godźiło jeść / áni tym którzy z nim byli : tylko ſámym kápłánom.
-Albośćie nie cżytáli w zakonie / że w Sábbát y kápłáni w Kośćiele Sábbát gwáłcą / á bez winy ſą?
+W on cżás / ƺedł JEzus w Sábbát przez zbożá á ucżniowie jego łáknęli / y pocżęli rwáć kłoſy y jeść.
+A ujrzawƺy to Fáryzeuƺowie / rzekli mu ; Oto ucżniowie twoji cżynią / cżego śię nie godźi cżynić w Sábbát.
+A on im rzekł ; Izaśćie nie cżytáli co ucżynił Dawid gdy łáknął on / y ći którzy z nim byli?
+Jáko wƺedł do domu Bożego / y chleby pokłádne jadł / których mu śię nie godźiło jeść / áni tym którzy z nim byli : tylko ſámym Kápłanom.
+Abośćie nie cżytáli w zakonie / że w Sábbát y Kápłani w Kośćiele Sábbát gwałcą / á bez winy ſą?
 Ale mówię wam / iż tu więkƺy jeſt niż Kośćiół.
-A gdybyśćie wiedźieli co to jeſt ; Miłośierdźiá chcę / á nie ofiáry : nie potępiálibyśćie niewinnych.
+A gdybyśćie wiedźieli co to jeſt ; Miłośierdźia chcę / á nie ofiáry : nie potępiálibyśćie niewinnych.
 Abowiem Syn cżłowiecży PAnem jeſt y Sábbátu.
 A odƺedƺy z támtąd / przyƺedł do bóżnice ich.
-A oto był tám cżłowiek májący rękę uſchłą : y pytáli go / mówiąc : Godźili śię w Sábbát uzdráwiáć? áby go oſkárżyli.
+A oto był tám cżłowiek májący rękę uſchłą : y pytáli go / mówiąc : Godźili śię w Sábbát uzdrawiáć? áby go oſkárżyli.
 A on im rzekł : Któryż cżłowiek z was będźie / któryby miał owcę jednę : á gdyby mu tá w Sábbát w dół wpádłá / izali jey nie dobędźie / y nie wyćiągnie?
-A cżemże zácniejƺy jeſt cżłowiek niżeli owcá? Przetoż / godźi śię w Sábbát dobrze cżynić.
-Tedy rzekł cżłowiekowi onemu ; Wyćiągnij rękę twoję. A on wyćiągnął ; y przywróconá jeſt do zdrowiá jáko y drugá.
+A cżymże zacniejƺy jeſt cżłowiek niżeli owcá? Przetoż / godźi śię w Sábbát dobrze cżynić.
+Tedy rzekł cżłowiekowi onemu ; Wyćiągni rękę twoję. A <i>on</i> wyćiągnął ; y przywrócona jeſt do zdrowia jáko y druga.
 A wyƺedƺy Fáryzeuƺowie / ucżynili rádę przećiwko niemu / jákoby go ſtráćili.
-Ale JEzus poznáwƺy <i>to,</i> odƺedł z támtąd : y ƺedł zá nim lud wielki : y uzdrowił one wƺyſtkie :
-Y przygroźił im / áby go nie objáwiáli.
-Żeby śię wypełniło co powiedźiáno przez Izájáƺá proroká / mówiącego ;
-Oto ten ſługá mój / któregom obrał ; ten umiłowány mój / w którym śię upodobáło duƺy mojey : położę duchá mojego ná nim / á ſąd národom opowie.
+Ale JEzus poznawƺy <i>to,</i> odƺedł z támtąd : y ƺedł zá nim lud wielki : y uzdrowił one wƺyſtkie :
+Y przygroźił im / áby go nie objawiáli.
+Żeby śię wypełniło co powiedźiano przez Izájaƺá Proroká / mówiącego ;
+Oto ten ſługá mój / któregom obrał ; ten umiłowány mój / w którym śię upodobáło duƺy mojey : położę Duchá mojego ná nim / á ſąd narodom opowie.
 Nie będźie śię wádźił / áni będźie wołał ; y nikt ná ulicách nie uſłyƺy głoſu jego.
-Trzćiny náłámáney nie dołámie / á lnu kurzącego śię nie zágáśi ; áż wyſtáwi ſąd ku zwyćięſtwu :
-A w imieniu jego národowie będą nádźieję mieli.
+Trzćiny náłąmáney nie dołamie / á lnu kurzącego śię nie zágáśi ; áż wyſtáwi ſąd ku zwyćięſtwu :
+A w Imieniu je° narodowie będą nádźieję mieli.
 Tedy przywiedźiono do niego opętánego / ślepego y niemego : y uzdrowił go ; ták / iż on ślepy y niemy / y mówił y widźiał.
 Y zdumiał śię wƺyſtek lud / y mówili ; Nie tenże jeſt on Syn Dawidów?
-Ale Fáryzeuƺowie uſłyƺáwƺy to / rzekli ; Ten nie wygánia Dyábłów / tylko przez Beelzebubá Kśiążę Dyábelſkie.
-Lecż JEzus widząc myśli ich / rzekł im ; Káżde króleſtwo rozdźielone ſámo przećiwko ſobie / puſtoƺeje ; y káżde miáſto álbo dom ſám przećiwko ſobie rozdźielony / nieoſtoi śię.
-A jeſliż ƺátán ƺátáná wygánia / ſám przećiwko ſobie rozdźielony jeſt : jákoż śię tedy oſtoi króleſtwo jego?
-A jeſliż Ja przez Beelzebubá wygániám dyábły / ſynowie wáśi przez kogoż wygániáją? Przetoż oni ſędźiámi wáƺymi będą.
-A jeſliż Ja Duchem Bożym wygániám dyábły / tedyć do was przyƺło Króleſtwo Boże.
-Albo jákoż może kto wnijść do domu Mocárzá / y ſprzęt jego rozchwyćić? Jeſliby pierwej nie związał mocárzá onego; toż dopiero dom jego rozchwyći.
-Kto nie jeſt zemną / przećiwko mnie jeſt ; á kto nie zbierá zemną / rozpráƺá.
-Dla tego powiádám wam ; Wƺelki grzech y bluźnierſtwo ludźiom odpuƺcżone będźie : ále bluźnierſtwo przećiwko Duchowi Świętemu nie będźie odpuƺcżone ludźiom.
-Y ktobykolwiek rzekł ſłowo przećiwko Synowi cżłowiecżemu / będźie mu odpuƺcżono : ále ktoby mówił przećiwko Duchowi Świętemu / nie będźie mu odpuƺcżono / áni w tym wieku / áni w przyƺłym.
-Cżyńćież álbo drzewo dobre / y owoc jego dobry : álbo cżyńćie drzewo złe / y owoc jego zły ábowiem z owocu drzewo poznáne bywa.
-Rodzáju jáƺcżurcży / jákoż możećie mówić dobre <i>rzecży</i> będąc złymi ; gdyż z obfitośći ſercá uſtá mówią.
-Dobry cżłowiek z dobrego ſkárbu ſercá / wynośi rzecży dobre ; á zły cżłowiek ze złego ſkárbu / wynośi rzecży złe.
-Ale powiádám wam / iż z káżdego ſłowá próżnego / któreby mówili ludźie / dádzą z niego licżbę w dźień ſądny.
+Ale Fáryzeuƺowie uſłyƺawƺy to / rzekli ; Ten nie wygania Dyabłów / tylko przez Beelzebubá Kśiążę Dyabelſkie.
+Lecż JEzus widząc myśli ich / rzekł im ; Káżde króleſtwo rozdźielone ſámo przećiwko ſobie / puſtoƺeje ; y káżde miáſto álbo dom ſam przećiwko ſobie rozdźielony / nie oſtoji śię.
+A jeſliż ƺátan ƺátáná wygania / ſam przećiwko ſobie rozdźielony jeſt : jákoż śię tedy oſtoji króleſtwo jego?
+A jeſliż Ja przez Beelzebubá wyganiam dyabły / ſynowie wáƺy przez kogoż wyganiáją? Przetoż oni ſędźiámi wáƺymi będą.
+A jeſliż Ja Duchem Bożym wyganiam dyabły / tedyć do was przyƺło Króleſtwo Boże.
+Albo jákoż może kto wniść do domu Mocárzá / y ſprzęt jego rozchwyćić? Jeſliby pierwey nie związał Mocárzá onego ; toż dopiero dom jego rozchwyći.
+Kto nie jeſt ze mną / przećiwko mnie jeſt ; á kto nie zbiera ze mną / roſpraƺa.
+Dla tego powiádam wam ; Wƺelki grzech y bluźnierſtwo ludźiom odpuƺcżone będźie : ále bluźnierſtwo przećiwko Duchowi <i>Świętemu</i> nie będźie odpuƺcżone ludźiom.
+Y ktobykolwiek rzekł ſłowo przećiwko Synowi cżłowiecżemu / będźie mu odpuƺcżono : Ale ktoby mówił przećiwko Duchowi świętemu / nie będźie mu odpuƺcżono / áni w tym wieku / áni w przyƺłym.
+Cżyńćież álbo drzewo dobre / y owoc jego dobry : álbo cżyńćie drzewo złe / y owoc jego zły. Abowiem z owocu drzewo poznáne bywa.
+Rodzáju jáƺcżórcży / jákoż możećie mówić dobre <i>rzecży</i> będąc złymi ; gdyż z obfitośći ſercá uſtá mówią.
+Dobry cżłowiek z dobrego ſkárbu ſercá / wynośi <i>rzecży</i> dobre ; á zły cżłowiek ze złego ſkárbu / wynośi <i>rzecży</i> złe.
+Ale powiádam wam / iż z káżdego ſłowá próznego / któreby mówili ludźie / dádzą z niego licżbę w dźień ſądny.
 Abowiem z mów twojich będźieƺ uſpráwiedliwiony / y z mów twojich będźieƺ oſądzony.
-Tedy odpowiedźieli niektórzy z Náucżonych w Piśmie / y Fáryzeuƺów / mówiąc ; Náucżyćielu chcemy od ćiebie známię widźieć.
-A on odpowiádájąc rzekł im ; Rodzáj zły y cudzołożny / známieniá ƺuká : ále mu nie będźie známię dáne / tylko ono známię Jonáƺá Proroká.
-Abowiem jáko Jonáƺ był w brzuchu Wielorybá trzy dni y trzy nocy : ták będźie Syn cżłowiecży w ſercu źiemie trzy dni y trzy nocy.
-Mężowie Niniwiccy ſtáną ná ſądźie z tym rodzájem / y potępią go / przeto / że pokutowáli ná kázánie Jonáƺowe : A oto tu więcey niżeli Jonáƺ.
-Królowá z Południá ſtánie ná ſądźie z tym rodzáje / y potępi go : iż przyƺłá od krájów źiemie / áby ſłucháłá mądrośći Sálomonowey : á oto tu więcey niżeli Sálomon.
-A gdy niecżyſty duch od cżłowieká wychodźi / przechádzá śię po miejſcách ſuchych / ƺukájąc odpocżnieniá : ále nie znájduje.
-Tedy mówi ; Wrócę śię do domu mego / ſkądem wyƺedł : á przyƺedƺy znájduje go próżny / y umiećiony / y ochędożony.
-Tedy idźie / y bierze z ſobą śiedmi inƺych duchów gorƺych niżeli ſám ; á wƺedƺy / mieƺkáją tám : y bywáją oſtátnie rzecży cżłowieká onego gorƺe / niżeli pierwƺe: ták śię ſtánie y temu rodzájowi złemu.
-A gdy on jeƺcże mówił do ludu / oto mátká y bráćia jego ſtáli przed domem / chcąc z nim mówić.
+Tedy odpowiedźieli niektórzy z Náucżonych w piśmie / y z Fáryzeuƺów / mówiąc ; Náucżyćielu chcemy od ćiebie známię widźieć.
+A on odpowiádájąc rzekł im ; Rodzaj zły y cudzołożny / známienia ƺuka : ále mu nie będźie známię dáne / tylko ono známię Jonaƺá Proroká.
+Abowiem jáko Jonaƺ był w brzuchu Wielorybá trzy dni y trzy nocy : ták będźie Syn cżłowiecży w ſercu źiemie trzy dni y trzy nocy.
+Mężowie Niniwitſcy ſtáną ná ſądźie z tym rodzájem / y potępią go / przeto / że pokutowáli ná kazánie Jonaƺowe : A oto tu więcey niżeli Jonaƺ.
+Królowa z Południá ſtánie ná ſądźie z tym rodzájem / y potępi go : iż przyƺłá od krájów źiemie / áby ſłucháłá mądrośći Sálomonowey : á oto tu więcey niżeli Sálomon.
+A gdy niecżyſty duch od cżłowieká wychodźi / przechadza śię po miejſcách ſuchych / ƺukájąc odpocżynienia : ále nie znájduje.
+Tedy mówi ; Wrócę śię do domu mego / z kądem wyƺedł : á przyƺedƺy znájduje <i>go</i> prózny / y umiećiony / y ochędożony.
+Tedy idźie / y bierze z ſobą śiedmi inƺych duchów gorƺych niżeli ſam ; á wƺedƺy / mieƺkáją tám : y bywáją oſtátnie rzecży cżłowieká onego gorƺe / niżeli pierwƺe : ták śię ſtánie y temu rodzájowi złemu.
+A gdy on jeƺcże mówił do ludu / oto mátká y bráćia jego ſtali przed domem / chcąc z nim mówić.
 Y rzekł mu niektóry ; Oto mátká twojá y bráćia twoji ſtoją przed domem / chcąc z tobą mówić.
-A on odpowiádájąc / rzekł temu co mu to powiedźiał ; Któráż jeſt mátká mojá? y którzy ſą bráćia moji?
-A wyćiągnąwƺy rękę ſwoję ná ucżnie ſwoje / rzekł ; Oto mátká mojá / y bráćia moji!
+A on odpowiádájąc / rzekł temu co mu to powiedźiał ; Któraż jeſt mátká moja? y którzy ſą bráćia moji?
+A wyćiągnąwƺy rękę ſwoję ná ucżnie ſwoje / rzekł ; Oto mátká mojá / y bráćia moji.
 Abowiem ktobykolwiek cżynił wolą Ojcá mojego / który jeſt w niebieśiech / ten jeſt brátem mojim / y śioſtrą / y mátką.


### PR DESCRIPTION
w.5. 1606 ma "nie cżytáli" osobno, podobnie w.7. - "nie potępiálibyśćie"
w.14. 1632 i 1660 mają "wƺedƺy"; 1606 "wyƺedƺy"'; KJV "went out"
w.32. 1606 ma "Duchowi Świętemu"
w.38. 1606 nie ma "z" w "z Fáryzeuƺów"