### PR TITLE
Mat.3.

### DIFF
--- a/1632/40-mat/03.txt
+++ b/1632/40-mat/03.txt
@@ -1,4 +1,4 @@
-A w one dni / przyƺedł Jan Chrzćićiel / każąc ná puƺcży w źiemi Judſkiej /
+A w one dni / przyƺedł Jan Chrzćićiel / każąc ná puƺcży w źiemi Judſkiey /
 A mówiąc : Pokutujćie ; Abowiem śię przybliżyło króleſtwo Niebieſkie.
 Tenći bowiem jeſt on / o którym powiedźiano przez Izájaƺá Proroká / mówiącego ; Głos wołájącego ná puƺcży : Gotujćie drogę PAńſką / proſte cżyńćie śćieżki jego.
 A ten Jan miał odźienie z śierśći wielbłądowey / y pás ſkórzány około biódr ſwojich ; á pokarm jego był / ƺáráńcża y miód leśny.
@@ -12,6 +12,6 @@ Jać was chrzcżę wodą ku pokućie : Ale ten / który idźie zá mną / mocnie
 Którego łopátá <i>jeſt</i> w ręku jego / á wycżyśći bojewiſko ſwoje / y zgromádźi pƺenicę ſwoję do gumná ; ále plewy ſpali ogniem nieugáƺonym.
 Tedy JEzus przyƺedł od Gálilejey nád Jordan do Janá / áby był ochrzcżony od niego.
 Ale mu Jan bárzo zábraniał / mówiąc ; Ja potrzebuję ábym był ochrzcżony od ćiebie / á ty idźieƺ do mnie?
-A odpowiádájąc JEzus / rzekł do niego ; Zániechaj teraz ; ábowiem ták przyſtoji ná nas / ábyſmy wypełnili wƺelką ſpráwiedliwość : Tedy go zániechał.
+A odpowiádájąc JEzus / rzekł do niego : Zániechaj teraz ; ábowiem ták przyſtoji ná nas / ábyſmy wypełnili wƺelką ſpráwiedliwość : Tedy go zániechał.
 A JEzus ochrzcżony będąc / wnet wyſtąpił z wody. A oto śię mu otworzyły niebioſá ; y widźiał Duchá Bożego zſtępującego jáko gołębicę / y przychodzącego nań.
 A oto głos z niebios mówiący ; Ten jeſt on Syn mój miły / w którym mi śię upodobáło.


### PR DESCRIPTION
w.3. 1606 ma "śćieƺki", także w innym miejscu 1632 występuje to słowo przez "ƺ"