### PR TITLE
Mat.17,27.

### DIFF
--- a/1879/40-mat/17.txt
+++ b/1879/40-mat/17.txt
@@ -24,4 +24,4 @@ I zabiją go, ale trzeciego dnia zmartwychwstanie. I zasmucili się bardzo.
 A gdy przyszli do Kapernaum, przystąpili do Piotra ci, którzy podatek wybierali, i rzekli: Izali nauczyciel wasz nie daje podatku?
 I rzekł: Daje. A gdy wchodził w dom, uprzedził go Jezus, mówiąc: Cóż ci się zda, Szymonie? Królowie ziemscy od kogoż biorą cło albo czynsz? od synów swoich, czyli od obcych?
 Rzekł mu Piotr: Od obcych. I rzekł mu Jezus: Toć tedy synowie są wolni.
-Wszakże abyśmy ich nie zgorszyli, szedłszy do morza, zarzuć wędkę, a tę rybę, która najpierwej uwięźnie, weźmij, a otworzywszy gębę jej, znajdziesz stater, który wziąwszy, daj im za mię i za się.
+Wszakże abyśmy ich nie zgorszyli, szedłszy do morza, zarzuć wędę, a tę rybę, która najpierwej uwięźnie, weźmij, a otworzywszy gębę jej, znajdziesz stater, który wziąwszy, daj im za mię i za się.


### PR DESCRIPTION
Literówka - względem 1632 oraz reszty tekstu z 1879 w którym również występuje "wędę", "wędą"