### PR TITLE
Objaw.12.

### DIFF
--- a/1632/66-apo/12.txt
+++ b/1632/66-apo/12.txt
@@ -1,4 +1,4 @@
-Y ukazał śię cud wielki ná niebie : Niewiáſtá oblecżoná w Słońce / á kśiężyc pod nogámi jey / á ná głowie jey byłá koroná / z dwunaści gwiazd.
+Y ukazał śię cud wielki ná niebie : Niewiáſtá oblecżona w Słońce / á kśiężyc pod nogámi jey / á ná głowie jey byłá koroná / z dwunaśći gwiazd.
 A będąc brzemienna wołáłá prácując ku porodzeniu / y męcżyłá śię áby porodźiłá.
 Y ukazał śię drugi cud ná niebie / á oto Smok wielki rydzy / májąc śiedm głów / y rogów dźieśięć / á ná głowách jego śiedm koron :
 A ogon jego ćiągnął trzećią cżęść gwiazd niebieſkich / y zrzućił je ná źiemię : á Smok on ſtánął przed niewiáſtą która miáłá porodźić / áby ſkoroby porodźiłá / pożárł dźiećię jey.
@@ -11,7 +11,7 @@ Y ſłyƺałem głos wielki mówiący ná niebie ; Terazći śię ſtáło zbáw
 Ale go oni zwyćiężyli przez krew Báránká y przez ſłowá świádectwá ſwego / á nie umiłowáli duƺe ſwojey áż do śmierći.
 Przetoż rozweſelćie śię niebá / y wy którzy mieƺkaćie ná nich. Biádá <i>mieƺkájącym</i> ná źiemi y ná morzu : iż zſtąpił Dyabeł do was / májąc wielki gniew / wiedząc iż krótki cżás ma.
 A gdy widźiał Smok / iż był zrżucony ná źiemię / prześládował niewiáſtę która byłá porodźiłá mężcżyznę.
-Y dáno niewieśćie dwie ſkrzydle Orłá wielkiego / áby lećiáłá od oblicżnośći wężowey ná puſtynią / ná miejſce ſwoje ; gdźieby ją żywiono przez cżás / y cżáſy / y połowicę cżáſu.
+Y dano niewieśćie dwie ſkrzydle Orłá wielkiego / áby lećiáłá od oblicżnośći wężowey ná puſtynią / ná miejſce ſwoje ; gdźieby ją żywiono przez cżás / y cżáſy / y połowicę cżáſu.
 Y wypuśćił wąż z gęby ſwojey zá niewiáſtą wodę jáko rzekę / chcąc ſpráwić áby ją rzeká porwáłá.
 Ale źiemiá rátowáłá niewiáſtę : y otworzyłá źiemiá uſtá ſwoje / y wypiłá rzekę / którą był wypuśćił Smok z gęby ſwojey.
 Y rozgniewał śię Smok ná niewiáſtę / y poƺedł áby walcżył z drugimi z naśienia jey / którzy záchowywáją przykazánia Boże / y máją świádectwo JEzuſá CHryſtuſá.

--- a/1632/66-apo/12.txt
+++ b/1632/66-apo/12.txt
@@ -9,7 +9,7 @@ Ale nie przemogli / áni miejſce ich dáliey ználeźione jeſt ná niebie.
 Y zrzucony jeſt Smok wielki / wąż on ſtárodawny ; którego zowią Dyabłem y Szátánem / który zwodźi wƺyſtek okrąg świátá : zrzucony jeſt ná źiemię / y Anjołowie jego z nim ſą zrżuceni.
 Y ſłyƺałem głos wielki mówiący ná niebie ; Terazći śię ſtáło zbáwienie / y moc / y króleſtwo Bogá náƺego / y zwierżchność CHryſtuſá jego : iż zrzucony jeſt oſkárżyćiel bráći náƺey / który ná nie ſkárżył / przed oblicżnośćią Bogá náƺego we dnie y w nocy.
 Ale go oni zwyćiężyli przez krew Báránká y przez ſłowá świádectwá ſwego / á nie umiłowáli duƺe ſwojey áż do śmierći.
-Przetoż rozweſelćie śię niebá / y wy którzy mieƺkaćie ná nich. Biádá mieƺkájącym ná źiemi y ná morzu : iż zſtąpił Dyabeł do was / májąc wielki gniew / wiedząc iż krótki cżás ma.
+Przetoż rozweſelćie śię niebá / y wy którzy mieƺkaćie ná nich. Biádá <i>mieƺkájącym</i> ná źiemi y ná morzu : iż zſtąpił Dyabeł do was / májąc wielki gniew / wiedząc iż krótki cżás ma.
 A gdy widźiał Smok / iż był zrżucony ná źiemię / prześládował niewiáſtę która byłá porodźiłá mężcżyznę.
 Y dáno niewieśćie dwie ſkrzydle Orłá wielkiego / áby lećiáłá od oblicżnośći wężowey ná puſtynią / ná miejſce ſwoje ; gdźieby ją żywiono przez cżás / y cżáſy / y połowicę cżáſu.
 Y wypuśćił wąż z gęby ſwojey zá niewiáſtą wodę jáko rzekę / chcąc ſpráwić áby ją rzeká porwáłá.


### PR DESCRIPTION
w.9, 10 i 13 - słowa "zrżuceni" i "zwierżchność" w 1660 występują bez kropki w dwuznaku "rz". Podobnie 1660 poprawia w innych miejscach. Niewykluczone że taka pisownia występuje tylko dla w.w. wyrazów - można sprawdzić czy także w innych księgach występuje pisownia "rż".