### PR TITLE
Mat.14,19.

### DIFF
--- a/1632/40-mat/14.txt
+++ b/1632/40-mat/14.txt
@@ -16,7 +16,7 @@ A gdy nádchodźił wiecżór / przyſtąpili do niego ucżniowie jego mówiąc 
 A JEzus im rzekł : Nie potrzebá im odchodźić / dajćie wy im co jeść.
 Ale mu oni rzekli : Nie mamy tu tylko pięć chlebów / y dwie rybie.
 A on rzekł : Przynieśćie mi je tu.
-Y rozkazawƺy ludowi uśieść ná trawie / wźiął onych pięć chlebów / y dwie rybie : á wejrzawƺy w niebo / błogoſłáwił : á łąmiąc / dawał ucżniom chleby / á ucżniowie ludowi.
+Y rozkazawƺy ludowi uśieść ná trawie / wźiął onych pięć chlebów / y dwie rybie : á wejrzawƺy w niebo / błogoſłáwił : á łamiąc / dawał ucżniom chleby / á ucżniowie ludowi.
 Y jedli wƺyſcy / á náſyceni byli : y zebráli co zbywáło ułomków dwánaśćie koƺów pełnych.
 A tych którzy jedli / było około piąći tyśięcy mężów / oprócż niewiaſt y dźiatek.
 A wnetże przymuśił JEzus ucżnie ſwoje / áby wſtąpili w łódź y uprzedźili go ná drugą ſtronę / áżby rozpuśćił lud.


### PR DESCRIPTION
Sprawdziłem wystąpienie słowa "łamiąc" dla Łuk.24,30. Dzieje.2,46. Mich.3,3. oraz Ps.58,8. i zarówno dla 1632, jak i 1660 występuje "łamiąc" zamiast "łąmiąc", zatem dla niniejszego wersetu występuje zapewne literówka w obu skanach.