### PR TITLE
3 Jan.1.

### DIFF
--- a/1632/64-joh/01.txt
+++ b/1632/64-joh/01.txt
@@ -1,15 +1,15 @@
 Stárƺy / Gájowi miłemu / którego ja miłuję w prawdźie.
 Namilƺy / naprzód żądam / ábyć śię dobrze powodźiło / y ábyś był zdrów / ták jáko śię dobrze powodźi duƺy twojey.
 Abowiem wielcem śię urádował / gdy przyƺli bráćia / y dáli świádectwo o twojey ƺcżerości / jáko ty wƺczerości chodźiƺ.
-Więkƺey nád tę rádośći nie mam ; jáko gdy ſłyƺę / iż dźiatki moje chodzą w ƺcżerośći.
+Więkƺey nád tę rádośći nie mam ; <i>jáko</i> gdy ſłyƺę / iż dźiatki moje chodzą w ƺcżerośći.
 Namilƺy / wiernie cżyniƺ cokolwiek cżyniƺ przećiwko bráći / y przećiw gośćiom.
 Którzy świádectwo wydáli o miłośći twojey przed Zborem : Y dobrze ucżyniƺ / jeſli je odprowádźiƺ jáko przyſtoji przed Bogiem.
 Abowiem dla Imienia jego wyƺli / nic nie wźiąwƺy od Pogánów.
 My tedy tákowe powinniſmy przymowáć : ábyſmy byli pomocnikámi prawdźie.
-Piſałem do Zboru waƺego : ále Diotrefes który chce bydż przedniejƺy miedzy nimi / nie przyjmuje nas.
-Przeto jeſli przydę / przypomnę ucżynki jego które cżyni ; ſłowy złymi obmawiájąc nas : á nie májąc doſyć ná tym / y ſam bráći nie przyjmuje / y tym coby przyjąć chćieli / zábrania / y ze Zboru je wyłącża.
+Piſałem do Zboru <i>wáƺego</i> : ále Diotrefes który chce bydż przedniejƺy miedzy nimi / nie przyjmuje nas.
+Przeto jeſli przydę / przypomnę ucżynki jego które cżyni ; ſłowy złymi obmawiájąc nas : á nie májąc doſyć ná tym / y ſam bráći nie przyjmuje / y tym coby <i>przyjąć</i> chćieli / zábrania / y ze Zboru je wyłącża.
 Namilƺy / nienáśláduj złego / ále dobrego. Kto dobrze cżyni z Bogá jeſt : Ale kto źle cżyni / nie widźiał Bogá.
-Demetryuƺowi świádectwo jeſt dáne od wƺyſtkich / y od ſámey prawdy : lecż y my świádectwo o nim dawamy ; á wiećie iż świádectwo náƺe prawdźiwe jeſt.
+Demetryuƺowi świádectwo jeſt dáne od wƺyſtkich / y od ſámey prawdy : lecż y my świádectwo <i>o nim</i> dawamy ; á wiećie iż świádectwo náƺe prawdźiwe jeſt.
 Wielem miał piſáć : lecż nie chcę piſáć inkauſtem y piórem.
-Bo mam nádźieję / że ćię w rychle ujrzę ; á tedy uſtnie mówić będźiemy.
-Pokój tobie. Pozdrawiáją ćię przyjaćiele. Pozdrów y ty przyjaćioły z imienia.
+Bo mam nádźieję / że ćię w rychle ujrzę ; á <i>tedy</i> uſtnie mówić będźiemy.
+Pokój tobie. Pozdrawiáją ćię przyjaćiele. Pozdrów <i>y ty</i> przyjaćioły z imienia.


### PR DESCRIPTION
w.14. w skanie 1632 i 1660 słowo "nadzieję" jest przez dwukrotne "ę".