### PR TITLE
2 Król.1.

### DIFF
--- a/1632/12-reg/01.txt
+++ b/1632/12-reg/01.txt
@@ -1,18 +1,18 @@
-Y odſtąpił Moáb od Izráelá po śmierći Achábowej.
-A Ochozyjáƺ ſpádł przez krátę ſáli ſwej / którą miał w Sámáryi / y rozniemógł śię. Y wypráwił poſły / mówiąc im : Idźćie / porádźćie śię Beelzebubá / bogá Akkárońſkiego / jeżeli powſtánę z tey choroby.
-Ale Anjoł Páńſki rzekł do Elijáƺá Teſbity : Wſtáń / idź przećiwko poſłom królá Sámáryi / y mów do nich : Izali niemáƺ Bogá w Izráelu / iż śię idźiećie rádźić Beelzebubá / bogá Akkárońſkiego?
-Przetoż ták mówi Pán : Z łożá / ná któreś śię położył / nie wſtánieƺ / ále pewnie umrzeƺ. Y odƺedł Elijáƺ.
+Y odſtąpił Moáb od Izráelá po śmierći Achábowey.
+A Ochoziaƺ ſpadł przez kratę Sale ſwey / którą miał w Sámáryjey / y rozniemógł śię : y wypráwił poſły / mówiąc im / Idźćie / poradźćie śię Beelzebubá / Bogá Akkárońſkiego / jeżeli powſtánę z tey choroby?
+Ale Anjoł Páńſki rzekł do Eliaƺá Tesbity : Wſtań / idź przećiwko poſłom Królá Sámáryjey / y mów do nich : Izali niemáƺ Bogá w Izráelu / iż śię idźiećie rádźić Beelzebubá / Bogá Akkárońſkiego?
+Przetoż ták mówi PAN : Z łożá ná któreś śię położył / nie wſtánieƺ ; ále pewnie umrzeƺ. Y odƺedł Eliaƺ.
 A gdy śię poſłowie wróćili do niego / rzekł do nich : Cżemużeśćie śię wróćili?
-Odpowiedźieli mu : Mąż niektóry záƺedł nam drogę / y mówił do nas : Idźćie / wróććie śię do królá / który was poſłał / y rzecżćie mu : Ták mówi Pán : Izáliż niemáƺ Bogá w Izráelu / że śię poſyłáƺ rádźić Beelzebubá / bogá Akkárońſkiego? Przetoż z łożá / ná któreś śię położył / nie wſtánieƺ / ále pewnie umrzeƺ.
-Y rzekł do nich : Cóż zá oſobá byłá tego mężá / który wam záƺedł drogę / y mówił do was te ſłowá?
-Y opowiedźieli mu : Mąż koſmáty / á páſem ſkórzánym przepáſány ná biodrách ſwych. Y rzekł : Elijáƺ Teſbitá jeſt.
-Przetoż poſłał do niego pięćdźieśiątniká z pięćdźieśięćiomá jego / który poƺedł do niego / ( á oto śiedźiał ná wierzchu góry / )i rzekł mu : Mężu Boży / król rozkázał / ábyś zſtąpił.
-A odpowiádájąc Elijáƺ / rzekł pięćdźieśiątnikowi : Jeſliżem jeſt mąż Boży / niech ogień zſtąpi z niebá / á pożre ćiebie y pięćdźieśięćiu twojich. Zſtąpił tedy ogień z niebá / y pożárł go y pięćdźieśięćiu jego.
-Znowu poſłał do niego pięćdźieśiątniká drugiego z pięćdźieśięćiomá jego / który mówił do niego / y rzekł : Mężu Boży / ták mówi król : Rychło zſtąp.
-Y odpowiedźiał Elijáƺ / á rzekł mu : Jeſlim jeſt mąż Boży / niech zſtąpi ogień z niebá / á pożre ćiebie y pięćdźieśiąt twojich. Tedy zſtąpił ogień Boży z niebá / y pożárł go y pięćdźieśięćiu jego.
-Tedy jeƺcże poſłał pięćdźieśiątniká trzećiego z pięćdźieśięćiomá jego. Przetoż poƺedł pięćdźieśiątnik on trzeći / á przyƺedƺy poklęknął ná koláná ſwoje przed Elijáƺem / á proƺąc go pokornie / mówił do niego : Mężu Boży / proƺę niech będźie drogá duƺá mojá / y duƺá tych ſług twojich pięćdźieśięćiu w ocżách twojich :
-Oto zſtąpił ogień z niebá / y pożárł dwu pięćdźieśiątników pierwƺych z pięćdźieśięćiu ich ; ále teraz niech będźie drogá duƺá mojá w ocżách twojich.
-Y rzekł Anjoł Páńſki do Elijáƺá : Zſtąp z nim / nie bój śię twárzy jego. Który wſtáwƺy poƺedł z nim do królá.
-Y rzekł mu : Ták mówi Pán : Przeto / żeś wypráwił poſły rádźić śię Beelzebubá / bogá Akkárońſkiego / jákoby Bogá nie było w Izráelu / ábyś śię pytał ſłowá jego / dla tego z łożá / ná któremeś śię położył / nie wſtánieƺ / ále pewnie umrzeƺ.
-A ták umárł według ſłowá Páńſkiego / które mówił Elijáƺ. Y królował Jorám miáſto niego / roku wtórego Jorámá / ſyná Jozáfátowego / królá Judzkiego ; ábowiem on nie miał ſyná.
-A inne ſpráwy Ochozyjáƺowe / które cżynił / ázaż nie ſą nápiſáne w kronikách o królách Izráelſkich?
+Odpowiedźieli mu : Mąż <i>niektóry</i> záƺedł nam drogę / y mówił do nas : Idźćie / wróććie śię do Królá / który was poſłał / y rzecżćie mu : Ták mówi PAN : Izaliż niemáƺ Bogá w Izráelu / że śię poſyłaƺ rádźić Beelzebubá Bogá Akkárońſkiego? przetoż z łożá ná któreś śię położył nie wſtánieƺ / ále pewnie umrzeƺ.
+Y rzekł do nich : Cóż zá oſobá <i>byłá</i> tego mężá / który wam záƺedł drogę / y mówił do was te ſłowá?
+Y odpowiedźieli mu : Mąż koſmáty / á páſem ſkórzánym przepáſány ná biodrách ſwych : Y rzekł : Eliaƺ Tesbitá jeſt.
+Przetoż poſłał do niego pięćdźieśiątniká / z piąćiądźieśiąt jego : który poƺedł do niego / ( á oto śiedźiał ná wierzchu góry ) y rzekł mu : Mężu Boży / Król rozkazał ábyś zſtąpił.
+A odpowiádájąc Eliaƺ / rzekł Pięćdźieśiątnikowi : Jeśliżem jeſt mąż Boży / niech ogień zſtąpi z niebá / á pożrże ćiebie y pięćdźieśiąt twojich. Zſtąpił tedy ogień z Niebá / y pożárł go / y pięćdźieśiąt jego.
+Znowu poſłał do niego Pięćdźieśiątniká drugiego / z piąćiądźieśiąt jego / który mówił do niego / y rzekł : Mężu Boży / ták mówi Król : Rychło zſtąp :
+Y odpowiedźiał Eliaƺ / á rzekł mu : Jeſlim jeſt mąż Boży / niech zſtąpi ogień z niebá / á pożrże ćiebie y pięćdźieśiąt twojich : Tedy zſtąpił ogień Boży z niebá / y pożárł go y pięćdźieśiąt jego.
+Tedy jeƺcże poſłał Pięćdźieśiątniká trzećiego / z piąćiądźieśiąt jego : Przetoż poƺedł pięćdźieśiątnik on trzeći : á przyƺedƺy poklęknął ná koláná ſwoje przed Eliaƺem : á proƺąc go pokornie mówił do niego : Mężu Boży / proƺę niech będźie droga duƺá mojá / y duƺá tych ſług twojich piąćidźieśiąt w ocżách twojich.
+Oto zſtąpił Ogień z Niebá / y pożárł dwu Pięćdźieśiątników pierwƺych z piąćiądźieśiąt ich ; Ale teraz niech będźie droga duƺá mojá w ocżách twojich :
+Y rzekł Anjoł Páńſki do Eliaƺá : Zſtąp z nim : nie bój śię twarzy jego. Który wſtawƺy poƺedł z nim do Królá.
+Y rzekł mu : Ták mówi PAN ; Przeto żeś wypráwił poſły rádźić śię Beelzebubá Bogá Akkárońſkiego / ( jákoby Bogá nie było w Izráelu / ábyś śię pytał ſłowá jego ) dla tego z łożá ná którymeś śię położył / nie wſtánieƺ / ále pewnie umrzeƺ.
+A ták umárł według ſłowá Páńſkiego / które mówił Eliaƺ. Y królował Jorám miáſto niego / roku wtórego / Jorámá Syná Jozáfátowego / Królá Judſkiego : ábowiem on nie miał Syná.
+A inne ſpráwy Ochoziaƺowe które cżynił / ázaż nie ſą nápiſáne w Kronikách o Królách Izráelſkich?


### PR DESCRIPTION
w.2. KJV ma "god" (z małej litery) podobnie w w.3. i w dalszych wersetach - zostawiłem tak, jak jest w skanie; oraz nie ma znaku zapytania po ostatnim słowie w tym wersecie.
w.6. "przetoż" możliwe że powinno być z dużej litery, choć 1660 nie poprawia tego.