### PR TITLE
2 Moj. 38.

### DIFF
--- a/1632/02-exo/38.txt
+++ b/1632/02-exo/38.txt
@@ -1,31 +1,31 @@
-Ucżynił też ołtárz ná cáłopálenie z drzewá ſytym / ná pięć łokći w dłuż / y ná pięć łokći w ƺerz / cżworográniſty / á ná trzy łokćie w zwyż.
-Y ucżynił mu rogi ná cżterech węgłách jego ; z niego wychodźiły rogi jego / á obił je miedźią.
-Pocżynił też wƺelákie nacżynia do ołtárzá / kotły / y miotły / y miednice / y widły / y łopáty / wƺyſtkie nacżynia jego ucżynił z miedźi.
-Ucżynił też do ołtárzá krátę miedźiáną ná kƺtáłt śieći miedzy okręgiem jego / od ſpodku áż do połowy jego.
-Y ulał cżtery kolce ná cżterech rogách kráty miedźiáney / ná zákłádánie drążków.
-Drążki tákże porobił z drzewá ſytym / á obił je miedźią.
-Y przewlókł drążki przez one kolce po ſtronách ołtárzá / áby noƺony był ná nich ; cżcży z deſek ucżynił go.
-Ucżynił też wánnę miedźiáną / y ſtolec jey miedźiány ze zwierćiádeł niewiáſt gromádą przychodzących / które przychodźiły do drzwi namiotu zgromádzenia.
-Ucżynił y śień ku ſtronie południowej ná południe / y opony śieni z biáłego jedwábiu kręconego / ná ſto łokći ;
-Słupów do nich dwádźieśćiá / y podſtáwków do nich dwádźieśćiá miedźiánych / główki ná ſłupiech / y okręceniá ich ſrebrne.
-Tákże ná ſtronie północney opon ná ſto łokći ; ſłupów do nich dwádźieśćiá y podſtáwków do nich miedźiánych dwádźieśćiá ; główki ná ſłupiech y okręceniá ich ſrebrne.
-A záśię od záchodniej ſtrony były opony ná pięćdźieśiąt łokći ; ſłupów do nich dźieśięć / y podſtáwków ich dźieśięć ; główki ná ſłupiech / y okręceniá ich ſrebrne.
-A ná ſtronie przedniej ku wſchodowi było opon ná pięćdźieśiąt łokći.
-Opony ná piętnaśćie łokći były po jedney ſtronie / ſłupów do nich trzy / y podſtáwków do nich trzy.
-A po drugiej ſtronie / ſtąd y z owąd u bramy śieni / opon piętnaśćie łokći / ſłupów do nich trzy / tákże podſtáwków do nich trzy.
-Wƺyſtkie opony śieni w około były z jedwábiu biáłego kręconego.
-A podſtáwki ſłupów miedźiáne / główki ná ſłupiech / y okręceniá ich ſrebrne / do tego przykryćie wierzchów ich ſrebrne ; á były okręcáne ſrebrem wƺyſtkie ſłupy śieni.
-Nád to záſłonę bramy u śieni ucżynił robotą háftárſką z hijácyntu / y z ƺárłátu y z kármázynu dwá kroć fárbowánego / y z jedwábiu kręconego ; ná dwádźieśćiá łokći byłá długość jey / wyſokość ƺeroká ná pięć łokći / jáko inne opony śieni.
-A ſłupów do nich cżtery / tákże podſtáwków ich cżtery miedźiánych ; główki ich ſrebrne / y zákryćiá wierzchów ich / tákże okręceniá ich ſrebrne.
-Tákże wƺyſtkie kołki przybytku / y śieni w około / były miedźiáne.
-Te ſą rzecży policżone do przybytku / do przybytku świádectwá / które policżone były ná rozkázánie Mojżeƺowe przez Itámárá / ſyná Aároná kápłáná / ku uſłudze Lewitom.
-A Beſáleel / ſyn Urów / ſyná Churowego z pokolenia Judy / ucżynił to wƺyſtko / co był Pán rozkázał Mojżeƺowi ;
-A z nim Acholijáb / ſyn Achyſámechów z pokolenia Dán / ćieślá / ſubtelny rzemieślnik / y háftujący ná hijácynćie / y ná ƺárłáćie / y ná kármázynie dwá kroć fárbowánym / y ná biáłym jedwábiu.
-Wƺyſtkiego złotá wynáłożonego ná ſámą robotę / ná wƺyſtką robotę świątnicy / które złoto było podárkowe / było dźiewięć y dwádźieśćiá tálentów / śiedm ſet y trzydźieśći ſyklów według ſyklá świątnicy.
-Srebrá záśię od policżonych w pocżet zgromádzenia ſto tálentów / y tyśiąc śiedm ſet śiedmdźieśiąt y pięć ſyklów według ſyklá świątnicy.
-Od káżdej głowy pół ſyklá według ſyklá świątnicy / od wƺyſtkich / którzy ƺli w licżbę / będąc we dwudźieſtu lat y dálej / których ludźi było ƺeść kroć ſto tyśięcy / y trzy tyśiące / y pięćſet / y pięćdźieśiąt.
-A było ſto tálentów ſrebrá do odlewánia podſtáwków świątnicy y podſtáwków záſłony ; ſto podſtáwków ze ſtá tálentów ; tálent ná podſtáwek.
-A z tyśiącá / śiedmiu ſet / śiedmdźieśiąt y pięćiu ſyklów ucżynił háki ná ſłupy / y powlókł wierzchy ich / y przepáſał je.
-Miedźi záś ofiárowáney było śiedmdźieśiąt tálentów / dwá tyśiące y cżtery ſtá ſyklów.
-Y ucżynił z niej podſtáwki do drzwi namiotu zgromádzenia / y ołtárz miedźiány / y krátę miedźiáną do niego / tákże wƺyſtko nacżynie do ołtárzá.
-Y podſtáwki do śieni w około ; tákże podſtáwki bramy śienney / y wƺyſtkie kołki przybytku / tákże kołki śieni w około.
+Uczynił też Ołtarz ná cáłopalenie z drzewá Syttym : ná pięć łokći w dłuż / y ná pięć łokći w ƺerz / czworográniſty : á ná trzy łokćie w zwyż.
+Y uczynił mu rogi ná czterech węgłách jego : z niego wychodźiły rogi jego / á obił je miedźią.
+Pocżynił też wƺelákie naczynia do Ołtarzá / kotły / y miotły / y miednice / y widły / y łopáty : wƺyſtkie naczynia jego uczynił z miedźi.
+Uczynił też do Ołtarzá kratę miedźiáną / ná kƺtałt śieći miedzy okręgiem jego / od ſpodku áż do połowice jego.
+Y ulał cztery kolcá ná czterech rogách kraty miedźiáney / ná zákładánie drążków.
+Drążki tákże porobił z drzewá Syttym / á obił je miedźią.
+Y przewlókł drążki przez one kolcá po ſtronách Ołtarzá / áby noƺony był ná nich : czcży / z deſk uczynił go.
+Uczynił też wánnę miedźiáną / y ſtolec jey miedźiány / ze zwierćiadł <i>niewiaſt</i> gromádą przychodzących które przychodźiły do drzwi namiotu zgromádzenia.
+Uczynił y śień ku ſtronie Południowey ná Południe : <i>y</i> opony śieni / z białego jedwabiu kręconego ná ſto łokći.
+Słupów do nich dwádźieśćiá / y podſtáwków do nich dwádźieśćiá miedźiánych / główki ná ſłupiech / y okręcenia ich / śrebrne.
+Tákże ná ſtronie pułnocney <i>opon</i> ná ſto łokći : ſłupów do nich dwádźieśćiá / y podſtáwków do nich miedźiánych dwádźieśćiá : główki ná ſłupách / y okręcenia ich śrebrne.
+A záśię od Zachodniey ſtrony / <i>były</i> opony ná pięćdźieśiąt łokći ; ſłupów do nich dźieśięć / y podſtáwków ich dźieśięć ; główki ná ſłupiech / y okręcenia ich śrebrne.
+A ná ſtronie przedniey ku wſchodowi / było opon ná pięćdźieśiąt łokći.
+Opony ná piąćinaśćie łokći <i>były</i> po <i>jedney</i> ſtronie : ſłupów do nich trzy / y podſtáwków do nich trzy.
+A po drugiey ſtronie / ztąd / y zowąd u bramy śieni / opon piętnaśćie łokći / ſłupów do nich trzy / tákże podſtáwków do nich trzy.
+Wƺyſtkie opony śieni w około <i>były</i> z jedwabiu białego kręconego.
+A podſtáwki ſłupów miedźiáne : główki ná ſłupiech / y okręcenia ich / śrebrne : do tego przykryćie wierzchów ich śrebrne : á były okręcáne śrebrem wƺyſtkie ſłupy śieni.
+Nád to zaſłonę bramy u śieni <i>uczynił</i> robotą háftárſką : z hyácyntu / y z ƺárłatu / y z kármázynu dwá kroć fárbowánego / y z jedwabiu kręconego : ná dwádźieśćiá łokći byłá długość jey / wyſokość ƺeroka ná pięć łokći jáko inne Opony śieni.
+A ſłupów do nich cztery / tákże podſtáwków ich cztery miedźiánych / główki ich śrebrne : y zákryćia wierzchów ich / tákże okręcenia ich śrebrne.
+Tákże wƺyſtkie kołki Przybytku / y śieni w około / <i>były</i> miedźiáne.
+Te ſą rzeczy policzone do przybytku / <i>do</i> Przybytku świádectwá / które policzone były ná rozkazánie Mojzeƺowe / przez Itámárá / Syná Aároná Kápłáná / ku uſłudze Lewitom.
+A Beſáleel Syn Urów / Syná Hurowego z pokolenia Judy / uczynił to wƺyſtko / co był PAN rozkazał Mojzeƺowi :
+A z nim Aholiáb / Syn Achiſámechów / z pokolenia Dán ćieślá / ſubtelny rzemieślnik / y háftujący ná hyácynćie / y ná ƺárłaćie / y ná kármázynie dwá kroć fárbowánym / y ná białym jedwabiu.
+Wƺyſtkiego złotá wynáłożonego ná <i>ſámę</i> robotę / ná wƺyſtkę robotę świątnice ( które złoto było podárkowe ) <i>było</i> dźiewięć y dwádźieśćiá talentów / śiedm ſet y trzydźieśći ſyklów / według ſyklá świątnice.
+Śrebrá záśię od policżonych w poczet zgromádzenia / ſto talentów / y tyśiąc / śiedm ſet śiedmdźieśiąt y pięć ſyklów / według ſyklá świątnice.
+Od káżdey głowy puł ſyklá / według ſyklá świątnice / od wƺyſtkich którzy ƺli w liczbę <i>będąc</i> we dwudźieſtu lat y dáley : <i>których ludźi</i> było ƺeść kroć ſto tyśięcy / y trzy tyśiące / y pięć ſet / y pięćdźieśiąt.
+A było ſto talentów śrebrá do odlewánia podſtáwków świątnice / y podſtáwków záſłony / ſto podſtáwków ze ſtá talentów : talent / ná podſtáwek.
+A z tyśiącá / śiedmi ſet / śiedmidźieśiąt y pięći <i>ſyklów,</i> uczynił haki ná ſłupy / y powlókł wierzchy ich / y przepáſał je.
+Miedźi záś ofiárowáney <i>było</i> śiedmdźieśiąt talentów / dwá tyśiącá / y cztery ſtá ſyklów.
+Y uczynił z niey podſtáwki do drzwi Namiotu zgromádzenia / y Ołtarz miedźiány / y kratę miedźiáną do niego / tákże wƺyſtko nacżynie <i>do</i> Ołtarzá.
+Y podſtáwki do śieni w około / tákże podſtáwki bramy śienney / y wƺyſtkie kołki przybytku / tákże kołki śieni / w około.


### PR DESCRIPTION
Słowo "łokiet" zamieniono wg 1660 na "łokći". 
![image](https://github.com/piotrskurzynski/biblia/assets/64212905/351afd5f-a1f9-48ae-bd2f-8acf344943af)
![image](https://github.com/piotrskurzynski/biblia/assets/64212905/9fec0f25-e285-45bc-8f6c-e92b8fff6edd)

