### PR TITLE
2 Moj.9,24.

### DIFF
--- a/1879/02-exo/09.txt
+++ b/1879/02-exo/09.txt
@@ -21,7 +21,7 @@ Kto się tedy uląkł słowa Pańskiego z sług Faraonowych, kazał uciekać sł
 Ale kto nie przyłożył serca swego do słowa Pańskiego, ten zostawił sługi swe i bydło swe na polu.
 I rzekł Pan do Mojżesza: Wyciągnij rękę twą ku niebu, że będzie grad po wszystkiej ziemi Egipskiej, na ludzi, i na bydło, i na wszelakie zioła polne w ziemi Egipskiej.
 A tak wyciągnął Mojżesz laskę swą ku niebu, a Pan dał gromy i grady, i zstąpił ogień na ziemię, i spuścił Pan grad na ziemię Egipską.
-I był grad, i ogień zmieszany z gradem ciężkim bardzo, jakiemu nie był podobny we wszystkiej ziemi Egipskiej, jako w niej mieszkać poczęto.
+I był grad, i ogień zmięszany z gradem ciężkim bardzo, jakiemu nie był podobny we wszystkiej ziemi Egipskiej, jako w niej mieszkać poczęto.
 I potłukł on grad po wszystkiej ziemi Egipskiej, cokolwiek było na polu, od człowieka aż do bydlęcia; i wszystko ziele polne potłukł grad, i wszystko drzewo polne połamał;
 Tylko w ziemi Gosen, gdzie synowie Izraelscy mieszkali, nie było gradu.
 Posłał tedy Farao, a wezwał Mojżesza i Aarona, mówiąc do nich: Zgrzeszyłem i tym razem; Pan jest sprawiedliwy, ale ja i lud mój niezbożniśmy.


### PR DESCRIPTION
w 1632 pisownia już jest przez "ę" - brak konieczności zamian w 1632.