### PR TITLE
2 Moj.29,40.

### DIFF
--- a/1879/02-exo/29.txt
+++ b/1879/02-exo/29.txt
@@ -37,7 +37,7 @@ Cielca też za grzech ofiarować będziesz na każdy dzień na oczyszczenie, i o
 Siedm dni będziesz oczyszczał ołtarz, i poświęcisz go, i będzie ten ołtarz najświętszy; cóżkolwiek się dotknie ołtarza, poświęcono będzie.
 A to jest, co ofiarować będziesz na ołtarzu: dwa baranki roczne, dwa na każdy dzień ustawicznie.
 Baranka jednego ofiarować będziesz rano, a baranka drugiego ofiarować będziesz między dwoma wieczorami.
-Także dziesiątą część efy mąki pszennej, zmieszanej z oliwą wytłoczoną, którejby było czwarta część hyn, a do ofiary mokrej czwarta część hyn wina do jednego baranka.
+Także dziesiątą część efy mąki pszennej, zmięszanej z oliwą wytłoczoną, którejby było czwarta część hyn, a do ofiary mokrej czwarta część hyn wina do jednego baranka.
 Także baranka drugiego ofiarować będziesz między dwoma wieczorami; według obrzędu ofiary porannej i według ofiary mokrej jej, tak przy niej uczynisz na wonią przyjemną, i ofiarę zapaloną Panu.
 Całopalenie to ustawicznie będzie w narodziech waszych u drzwi namiotu zgromadzenia przed Panem, gdzie się z wami schodzić będę, abym tam z tobą rozmawiał.
 Tam się też schodzić będę z synami Izraelskimi, i będzie miejsce to chwałą moją.


### PR DESCRIPTION
w 1632 pisownia już jest przez "ę" - brak konieczności zamian w 1632.