### PR TITLE
2 Król.7,2;19.

### DIFF
--- a/1632/12-reg/07.txt
+++ b/1632/12-reg/07.txt
@@ -1,5 +1,5 @@
 Tedy rzekł Elizeuƺ : Słuchájćie ſłowá Páńſkiego. Ták mówi Pán : O tym cżáśie jutro miárá mąki pƺenney będźie zá ſykiel / á dwie miáry jęcżmieniá zá ſykiel / w bramie Sámáryjſkiej.
-Y odpowiedźiał kśiąże / ná którego śię ręce król wſpierał / mężowi Bożemu / y rzekł : By też Pán pocżynił okná w niebie / izáliby to mogło być? Który mu rzekł : Oto ty ujrzyƺ ocżymá twemi ; ále tego jeść nie będźieƺ.
+Y odpowiedźiał Kśiążę / ná którego śię ręce król wſpierał / mężowi Bożemu / y rzekł : By też Pán pocżynił okná w niebie / izáliby to mogło być? Który mu rzekł : Oto ty ujrzyƺ ocżymá twemi ; ále tego jeść nie będźieƺ.
 A byli cżterej mężowie trędowáći u wejśćiá bramy / którzy rzekli jeden do drugiego : Pocóż tu mieƺkámy / áżbyſmy pomárli?
 Jeſli wnijdźiemy do miáſtá / głód w mieśćie / y pomrzemy tám / á jeſli tu zoſtániemy / przećię pomrzemy. Teraz tedy pójdźćie / á zbieżmy do obozu Syryjſkiego ; jeſli nas żywo zoſtáwią / będźiemy żywi ; jeſli nas też zábiją / pomrzemy.
 Wſtáli tedy / gdy śię zmierzcháć pocżęło / áby ƺli do obozu Syryjſkiego ; á przyƺedƺy ná koniec obozu Syryjſkiego / oto tám nie było nikogo.
@@ -16,5 +16,5 @@ Y ƺli zá nimi áż do Jordánu / á oto po wƺyſtkiej drodze pełno było ƺ�
 Przeto wyƺedƺy lud / rozchwyćił obóz Syryjſki ; á byłá miárá pƺenney mąki zá ſykiel / á dwie miáry jęcżmieniá zá ſykiel / według ſłowá Páńſkiego.
 A król poſtánowił był onego kśiążęćiá / ná którego śię ręce wſpierał / w bramie / którego lud podeptał w bramie / áż umárł / jáko mu był powiedźiał mąż Boży / który o tym mówił / gdy był król przyƺedł do niego.
 Y ſtáło śię według ſłowá / które był rzekł mąż Boży królowi / mówiąc : Dwie miáry jęcżmieniá zá ſykiel / á miárá pƺenney mąki będźie zá ſykiel / jutro o tym cżáśie w bramie Sámáryjſkiej.
-Ná co był odpowiedźiał on kśiąże mężowi Bożemu / mówiąc : By też Pán ucżynił okná w niebie / izali to będźie według ſłowá tego? A on mu rzekł : Oto ty ujrzyƺ ocżymá twemi / ále tego jeść nie będźieƺ.
+Ná co był odpowiedźiał on Kśiążę mężowi Bożemu / mówiąc : By też Pán ucżynił okná w niebie / izali to będźie według ſłowá tego? A on mu rzekł : Oto ty ujrzyƺ ocżymá twemi / ále tego jeść nie będźieƺ.
 Y ſtáło mu śię ták ; bo go podeptał lud w bramie / áż umárł.


### PR DESCRIPTION
w tym miejscu w tekście z 1879 nie występuje już pisownia przez "ę" co zapewne jest literówką, lecz to już sprawa na ujednolicenie pisowni podczas rewizji