### PR TITLE
Rzym.13,3.

### DIFF
--- a/1879/45-rom/13.txt
+++ b/1879/45-rom/13.txt
@@ -1,6 +1,6 @@
 Każda dusza niech będzie zwierzchnościom wyższym poddana: boć niemasz zwierzchności, tylko od Boga; a te, które są zwierzchności, od Boga są postanowione.
 A tak kto się zwierzchności sprzeciwia, Bożemu się postanowieniu sprzeciwia; a którzy się sprzeciwiają, sami sobie potępienie zjednają.
-Albowiem przełożoni nie są na postrach dobrym uczynkom, ale złym. A chcesz się nie bać zwierzchności, czyń, co jest dobrego, a będziesz miał pochwałę od niej;
+Albowiem przełożeni nie są na postrach dobrym uczynkom, ale złym. A chcesz się nie bać zwierzchności, czyń, co jest dobrego, a będziesz miał pochwałę od niej;
 Bożym bowiem jest sługą tobie ku dobremu. Ale jeźli uczynisz, co jest złego, bój się; boć nie darmo miecz nosi, gdyż jest sługą Bożym, mszczącym się w gniewie nad czyniącym, co jest złego.
 Przetoż trzeba być poddanym nie tylko dla gniewu, ale i dla sumienia.
 Albowiem dla tego też podatki dajecie, gdyż są sługami Bożymi, którzy tego samego ustawicznie pilnują.


### PR DESCRIPTION
literówka; w reszcie tekstu w 1879 występuje "przełożeni"; także por. 1632