### PR TITLE
Izaj.1,22.

### DIFF
--- a/1632/23-esa/01.txt
+++ b/1632/23-esa/01.txt
@@ -19,7 +19,7 @@ Przyjdźćież teraz / á rozpierájmy śię z ſobą / mówi Pán : Choćby by�
 Będźiećieli powolni / á poſłucháćie mię / dóbr źiemi pożywáć będźiećie.
 Lecż jeſli nie będźiećie poſłuƺnymi / ále odpornymi / od miecżá pożárći będźiećie ; bo uſtá Páńſkie mówiły.
 Jákoć śię ſtáło nierządnicą to miáſto wierne / pełne ſądu? Spráwiedliwość mieƺkáłá w nim ; lecż teraz mężobójcy.
-Srebro twoje obróćiło śię w żużeł ; wino twoje pomięƺáło śię z wodą.
+Srebro twoje obróćiło śię w zużel ; wino twoje pomięƺáło śię z wodą.
 Kśiążętá twoi ſą uporni / y towárzyƺe złodźiei ; káżdy z nich miłuje dáry / á jádą zá nágrodą ; śieroćie nie cżynią ſpráwiedliwośći / á ſpráwá wdowy nie przychodźi przed nich.
 Przetoż mówi Pán / Pán zaſtępów / możny Izráelſki : Oto ućieƺę śię nád nieprzyjáćiółmi moimi / á pomƺcżę śię nád przećiwnikámi ſwymi.
 Y obrócę rękę moję ná ćię / á wypálę áż do cżyſtá zużelicę twoję / y odpędzę wƺyſtkę cenę twoję.


### PR DESCRIPTION
pisownia przez "l" - także w słowniku xvi wieku występuje tylko pisownia przez "l":
https://spxvi.edu.pl/indeks/szukaj/?page=191&q=z