### PR TITLE
2 Król.5.

### DIFF
--- a/1632/12-reg/05.txt
+++ b/1632/12-reg/05.txt
@@ -1,27 +1,27 @@
-A Náámán / hetmán wojſká królá Syryjſkiego / był mąż wielki u páná ſwego / y oſobá zácná. Abowiem przezeń dał był Pán wybáwienie Syryjcżykom ; á ten mąż był duży w śile / ále trędowáty.
-A z Syryi wyƺłá byłá ſwáwolná kupá / która pojmáłá z źiemi Izráelſkiej dźiewecżkę nie wielką / á tá ſłużyłá żonie Náámánowej.
-Która rzekłá do páni ſwej : O gdyby śię pán mój doſtał do proroká / który jeſt w Sámáryi! pewnieby go uzdrowił od trądu jego.
-Wƺedł tedy Náámán / y oznájmił to pánu ſwemu / mówiąc : Ták á ták mówiłá dźiewecżká / która jeſt z źiemi Izráelſkiej.
-Ná co odpowiedźiał król Syryjſki : Idź / wypráw śię / á poślę liſt do królá Izráelſkiego. A ták jechał / wźiąwƺy z ſobą dźieśięć tálentów ſrebrá / y ƺeść tyśięcy złotych / y dźieśięćioro ƺát odmiennych.
-Y przynióſł liſt do królá Izráelſkiego w te ſłowá : Jáko ćię prędko dojdźie ten liſt / wiedz / żem poſłał do ćiebie Náámáná / ſługę mego / ábyś go uzdrowił od trądu jego.
-A gdy przecżytał król Izráelſki liſt / rozdárł odźienie ſwoje / mówiąc : Azáżem ja jeſt Bóg / żebym mógł umorzyć y ożywić / iż ten do mnie śle / ábym uzdrowił mężá tego od trądu jego? Uwáżćie proƺę / á obácżćie / że ƺuká przycżyny ná mię.
-Co gdy uſłyƺał Elizeuƺ / mąż Boży / iż rozdárł król Izráelſki ƺáty ſwe / poſłał do królá / mówiąc : Przecżżeś rozdárł ƺáty ſwe? Niech przydźie do mnie / á dowie śię / że jeſt prorok w Izráelu.
-A ták przyjechał Náámán z końmi ſwemi / y z wozem ſwym / y ſtánął u drzwi domu Elizeuƺowego.
-Y wyſłał do niego Elizeuƺ poſłá / mówiąc : Idź / á omyj śię śiedm kroć w Jordánie / á przywróćić śię zdrowie ćiáłá twego / y będźieƺ ocżyƺcżony.
-Tedy rozgniewáwƺy śię Náámán / brał śię w drogę / mówiąc : Otom myślał ſám u śiebie / iż pewnie wynijdźie / á ſtánąwƺy przy mnie / wzywáć będźie imienia Páná / Bogá ſwego / á podnióſƺy rękę ſwoję nád miejſcem trądu / uzdrowi trędowátego.
-Azaż nie lepƺe ſą rzeki Abáná y Fárfár w Dámáƺku nád wƺyſtkie wody Izráelſkie? izálibym śię niemógł w nich omyć / ábym śię ocżyśćił! A ták obróćiwƺy śię / odjeżdżał z gniewem.
-Ale przyſtąpiwƺy ſłudzy jego / mówili do niego / y rzekli : Ojcże mój / gdybyć był co wielkiego ten prorok rozkázał / ázáżbyś nie miał tego ucżynić? Jáko dáleko więcey / gdy rzekł : Omyj śię / á będźieƺ cżyſtym?
-Przetoż ƺedƺy omył śię w Jordánie śiedm kroć według ſłowá mężá Bożego ; y ſtáło śię ćiáło jego / jáko ćiáło dźiećięćiá máłego / y ocżyƺcżony jeſt.
-Potem śię wróćił do mężá Bożego / on y wƺyſtek pocżet jego / á przyƺedƺy ſtánął przed nim / y rzekł : Otom teraz poznał / że nie maƺ Bogá ná wƺyſtkiej źiemi / tylko w Izráelu : przetoż weźmij proƺę te upominki od ſługi twego.
-A on rzekł : Jáko żywy Pán / przed którego oblicżem ſtoję / że nic nie wezmę ; á choć go przymuƺał / áby wźiął / przećię nie chćiał.
-Y rzekł Náámán : A nie chceƺ? niechże będźie dáne proƺę ſłudze twemu brzemię źiemi ná dwá muły ; boć nie będźie ſpráwował więcey ſługá twój cáłopalenia y innych ofiár bogom cudzym / jedno Pánu.
-Wƺákże w tey mierze niech odpuśći Pán ſłudze ſwemu / gdy wchodźi pán mój do kośćiołá Remmon / áby śię tám kłániał / á weſprze śię ná ręce mojey / że śię y ja kłániám w kośćiele Remmon. Tákowe moje kłániánie w kośćiele Remmon proƺę niech odpuśći Pán ſłudze twemu w tey mierze.
-Y rzekł mu : Idź w pokoju. A gdy odjechał od niego / jákoby ná milę drogi /
-Rzekł Giezy / ſługá Elizeuƺá / mężá Bożego : Oto nie dopuśćił pán mój temu Náámánowi Syryjſkiemu / áby dał z ręki ſwej / co był przywiózł ; jáko żywy Pán / że pobieżę zá nim / á wezmę co od niego.
-A ták bieżał Giezy zá Náámánem. Którego ujrzáwƺy Náámán bieżącego zá ſobą / ſkocżył z wozu przećiw niemu / y rzekł : Dobrzeż śię wƺyſtko dźieje?
-Któremu odpowiedźiał : Dobrze. Pán mój poſłał mię / ábym ći powiedźiał : Oto dopiero teraz przyƺli do mnie dwáj młodźieńcy z góry Efráim z ſynów prorockich ; dájże im proƺę tálent ſrebrá / y dwie odmienne ƺáty.
-Tedy rzekł Náámán : Rádniej weźmij dwá tálenty. Y przymuśił go / y záwiązał dwá tálenty ſrebrá we dwá worki / y dwie odmienne ƺáty / y włożył ná dwu ſług ſwojich / którzy nieśli przed nim.
-A przyƺedƺy ná págórek / wźiął to z ręki ich / y złożył w niektórym domu / á męże one odpráwił / y odeƺli.
-Potem przyƺedƺy ſtánął przed pánem ſwym. Y rzekł do niego Elizeuƺ : Skądże Giezy? A on odpowiedźiał : Nie chodźił nigdźie ſługá twój.
-Ale mu on rzekł : Azaż ſerce moje nie chodźiło z tobą / kiedy śię obróćił on mąż z wozu ſwego przećiwko tobie? ázaż cżás był do bránia ſrebrá / y do bránia ƺát / y oliwnic / y winnic / y bydłá / y wołów / y ſług / y ſłużebnic?
-Przetoż trąd Náámánowy przylgnie do ćiebie / y do náśieniá twego ná wieki. Y wyƺedł od twárzy jego trędowáty / jáko śnieg.
+A Náámán / Hetman Wojſká Królá Syryjſkiego / był mąż wielki u Páná ſwego / y Oſobá zacna. Abowiem przezeń dał był PAn wybáwienie Syryjcżykom : á ten mąż był duży w śile / <i>ale</i> trędowáty.
+A z Syryjey wyƺłá byłá ſwawolna kupá / która pojimáłá z źiemie Izráelſkiey dźiewecżkę niewielką : á tá ſłużyłá żenie Náámánowey.
+Która rzekłá do Páni ſwey : O gdyby śię PAN mój doſtał do Proroká / który jeſt w Sámáryjey / pewnieby go uzdrowił od trędu jego.
+Wƺedł tedy <i>Náámán</i> y oznájmił to Pánu ſwemu / mówiąc : Ták á ták mówiłá dźiewecżká / która jeſt z źiemie Izráelſkiey.
+Ná co odpowiedźiał Król Syryjſki : Idź / wypraw śię / á poślę liſt do Królá Izráelſkiego. A ták jáchał / wźiąwƺy z ſobą dźieśięć talentów śrebrá / y ƺeść tyśięcy złotych / y dźieśięćioro ƺat odmiennych.
+Y przynióſł liſt do Królá Izráelſkiego w te ſłowá : Jáko ćię prętko dojdźie ten liſt / wiedz żem poſłał do ćiebie Náámáná ſługę mego / ábyś go uzdrowił od trędu jego.
+A gdy przecżytał Król Izráelſki liſt / rozdárł odźienie ſwoje / mówiąc : Azam ja jeſt Bóg żebym mógł umorzyć y ożywić iż ten do mnie śle / ábym uzdrowił mężá <i>tego</i> od trędu jego? Uważćie proƺę / á obacżćie / że ƺuka przycżyny ná mię.
+Co gdy uſłyƺał Elizeuƺ mąż Boży / iż rozdárł Król Izráelſki ƺáty ſwe / poſłał do Królá / mówiąc : Przecżżeś rozdárł ƺáty twe? niech przydźie do mnie / á dowie śię że jeſt Prorok w Izráelu.
+A ták przyjáchał Náámán z końmi ſwymi / y z wozem ſwym / y ſtánął u drzwi domu Elizeuƺowego.
+Y wyſłał do niego Elizeuƺ poſłá / mówiąc : Idź á omyj śię śiedm kroć w Jordanie / á przywróćić śię <i>zdrowie</i> ćiáłá twego / y będźieƺ ocżyśćiony.
+Tedy rozgniewawƺy śię Náámán / brał śię w drogę / mówiąc : Otom myślił ſam u śiebie / iż pewnie wynidźie / á ſtánąwƺy <i>przy mnie</i> wzywáć będźie Imienia PANA Bogá ſwego / á podnióżƺy rękę ſwoję nád miejſcem <i>trędu</i> uzdrowi trędowátego.
+Azaƺ nie lepƺe ſą rzeki Abáná y Fárfár w Dámáƺku / nád wƺyſtkie wody Izráelſkie? izalibym śię niemógł w nich omyć / ábym śię ocżyśćił? A ták obróćiwƺy śię odjeżdżał z gniewem.
+Ale przyſtąpiwƺy ſłudzy jego / mówili do niego / y rzekli : Ojcże mój / gdybyć był co wielkiego ten Prorok rozkazał / ázażbyś niemiał tego ucżynić? Jáko dáleko więcey / gdy rzekł ; Omyj śię / á będźieƺ cżyſtym?
+Przetoż ƺedƺy / omył śię w Jordanie śiedm kroć / według ſłowá mężá Bożego : Y ſtáło śię ćiáło jego / jáko ćiáło dźiećięćiá máłego : y ocżyśćiony jeſt.
+Potym śię wróćił do mężá Bożego / on y wƺyſtek pocżet jego / á przyƺedƺy ſtánął przed nim / y rzekł : Otom teraz poznał że niemáƺ Bogá ná wƺyſtkiey źiemi / tylko w Izráelu : przetoż weźmi / proƺę / te upominki od ſługi twego.
+Ale on rzekł : Żywie PAN / przed którego oblicżem ſtoję / że nic nie wezmę : á choć go przymuƺał áby wźiął / przećię nie chćiał.
+Y rzekł Náámán : A <i>nie chceƺ</i>? niechże będźie dáne / proƺę ſłudze twemu brzemię źiemie ná dwá muły : boć nie będźie ſpráwował więcey ſługá twój cáłopalenia / y <i>innych</i> ofiar Bogom cudzym / jedno PANU.
+<i>Wƺákże</i> w tey mierze / niech odpuśći PAN ſłudze ſwemu / gdy wchodźi PAN mój do kośćiołá Remmon / áby śię tám kłaniał / á weſprze śię ná ręce mojey / że śię y ja kłaniam w kośćiele Remmon : tákowe moje kłaniánie w kośćiele Remmon / proƺę niech odpuśći Pan ſłudze twemu w tey mierze.
+Y rzekł mu : Idź w pokoju. A gdy odjáchał od niego / jákoby ná milę drogi :
+Rzekł Gezy ſługá Elizeuƺá mężá Bożego : Oto nie dopuśćił PAN mój temu Náámánowi Syryjſkiemu / áby dał z ręki ſwey / co był przywiózł : żywie PAN / że pobieżę zá nim / á wezmę co od niego.
+A ták bieżał Gezy zá Náámánem / którego ujrzawƺy Náámán bieżącego zá ſobą zſkocżył z wozá przećiw niemu / y rzekł : Dobrzeż śię <i>wƺyſtko</i> dźieje?
+Któremu odpowiedźiał / Dobrze. PAN mój poſłał mię ábymći powiedźiał : Oto dopiero teraz przyƺli do mnie dwá młodźieńcy z góry Efráim / z Synów prorockich : dajże im proƺę talent śrebrá / y dwie odmienne ƺáćie.
+Tedy rzekł Náámán : Rádniey weźmi dwá talenty ; y przymuśił go : y záwiązał dwá talenty śrebrá we dwá worki / y dwie odmienne ƺáćie : y włożył ná dwu ſług ſwojich / którzy nieśli przed nim.
+A przyƺedƺy ná págórek / wźiął <i>to</i> z ręki ich / y złożył w niektórym domu / á męże <i>one</i> odpráwił / y odeƺli.
+Potym przyƺedƺy / ſtánął przed Pánem ſwym. Y rzekł do niego Elizeuƺ : Zkądże Gezy? A <i>on</i> odpowiedźiał : Nie chodźił nigdźie ſługá twój.
+Ale mu on rzekł : Azaż ſerce moje niechodźiło <i>z tobą</i> kiedy śię obróćił on mąż z wozá ſwego przećiwko tobie? ázaż cżás był do bránia śrebrá / y do bránia ƺat / y oliwnic / y winnic / y bydłá / y wołów / y ſług / y ſłużebnic?
+Przetoż trąd Náámánów przylnie do ćiebie / y do naśienia twego ná wieki. Y wyƺedł od twarzy jego trędowáty / jáko śnieg.


### PR DESCRIPTION
w 1632 ok. 5 razy "cż" jest pisane jako "cz", z kolei 1660 poprawia na wersję z kropką - zostawiłem tak jak w 1660