### PR TITLE
1 Moj.31,31.

### DIFF
--- a/1632/01-gen/31.txt
+++ b/1632/01-gen/31.txt
@@ -28,7 +28,7 @@ Przeczżeś potájemnie ućiekł / á wykradłeś śię odemnie / á nie oznájm
 Y nie dopuśćiłeś mi ábym pocáłował Syny moje / y córki moje. Zájiſte głupieś ſobie począł.
 Jeſt to w mocy ręki mojey uczynić wam co złego : ále Bóg Ojcá wáƺego przeƺłey nocy rzekł do mnie / mówiąc : Strzeż śię ábyś z Jákóbem nie mówił nic przykrego.
 A teraz gdyć śię chćiáło odejść / żeś wielce prágnął do domu Ojcá twego / czemużeś ukradł Bogi moje?
-Y odpowiádájąc Jákób / rzekł Lábánowi : Iżem śię bał y myślełem / byś mi ſnadź nie wydárł córek twojich.
+Y odpowiádájąc Jákób / rzekł Lábánowi : Iżem śię bał y myśliłem / byś mi ſnadź nie wydárł córek twojich.
 Lecz ten u kogo znajdźieƺ Bogi twoje / niech umrze przed bráćią náƺą : Poznajże co twego u mnie / y weźmi ſobie : á nie wiedźiał Jákób że je Ráchel ukrádłá.
 Wƺedł tedy Lábán do namiotu Jákóbowego / y do namiotu Lie / y do namiotu obudwu ſłużebnic / á nie nálazł / á wyƺedƺy z namiotu Lie / wƺedł do namiotu Ráchele.
 A Ráchel wźiąwƺy one báłwany włożyła je pod śiodło wielbłądowe / y uśiádłá ná nich / y zmácał Lábán wƺyſtek namiot / á nie ználazł.


### PR DESCRIPTION
por. 1660 oraz inne wystąpienia w 1632 (sprawdzone dla 3 fragmentów z 1 Moj, 2 Kron. i Ijob. że występuje pisownia przez "i")