### PR TITLE
2 Król.8.

### DIFF
--- a/1632/12-reg/08.txt
+++ b/1632/12-reg/08.txt
@@ -1,29 +1,29 @@
-Potem Elizeuƺ rzekł do oney niewiáſty / którey był ſyná wſkrześił / mówiąc : Wſtáń á idź / ty y dom twój / á bądź gośćiem / kędy będźieƺ mogłá być : bo záwołał Pán głodu / y przydźie ná źiemię przez śiedm lat.
-Wſtáłá tedy oná niewiáſtá / y ucżyniłá według ſłowá mężá Bożego ; á poƺłá oná y dom jey / y byłá gośćiem w źiemi Filiſtyńſkiej przez śiedm lat.
-Y ſtáło śię po wyśćiu śiedmiu lat / że śię wróćiłá oná niewiáſtá z źiemi Filiſtyńſkiej / y poƺłá / áby wołáłá ná królá o dom ſwój / y o rolę ſwoję.
-A ná ten cżás król rozmáwiał z Giezym / ſługą mężá Bożego / mówiąc : Powiedz mi proƺę wƺyſtkie zácne ſpráwy / które cżynił Elizeuƺ.
-A gdy on powiádał królowi / jáko wſkrześił umárłego / oto niewiáſtá / którey był wſkrześił ſyná / záwołáłá ná królá o dom ſwój y o rolę ſwoję. Y rzekł Giezy : Królu pánie mój / táć to jeſt niewiáſtá / y ten ſyn jey / którego wſkrześił Elizeuƺ.
-Y pytał król niewiáſty / á oná mu powiedźiáłá. Y przydał jey król komorniká jednego / mówiąc : Przywróć jey wƺyſtko / co jey było / y wƺyſtkie dochody z polá od onego dniá / którego opuśćiłá źiemię / áż dotąd.
-Potem przyƺedł Elizeuƺ do Dámáƺku / á Benádád / król Syryjſki / chorował. Y powiedźiáno mu / mówiąc : Przyƺedł tu mąż Boży.
-Y rzekł król do Házáelá : Weźmij w rękę ſwą upominek / á idź przećiwko mężowi Bożemu / y pytáj śię Páná przezeń / mówiąc : Wſtánęli z tey choroby?
-Przetoż ƺedł Házáel przećiwko niemu / á wźiąwƺy upominek w rękę ſwą / y ze wƺyſtkich dóbr Dámáſkich brzemion ná cżterdźieśći wielbłądów. Y przyƺedł / á ſtánął przed nim / mówiąc : Syn twój Benádád / król Syryjſki / poſłał mię do ćiebie / mówiąc : Wſtánęli z tey choroby?
-Y odpowiedźiał mu Elizeuƺ : Idź / powiedz mu : Wpráwdźiebyśći mógł żyć ; wƺákże okázał mi Pán / że pewnie umrze.
-Wtem pokázał mu / y ſtáwił twárz ſwoję ſmutną / y płákał mąż Boży.
-Któremu rzekł Házáel : Cżemuż pán mój płácże? Y odpowiedźiał : Iż wiem / co ucżyniƺ złego ſynom Izráelſkim. Twierdze ich popáliƺ ogniem / á młodźieńce ich miecżem pomordujeƺ / y dźieći ich poroztrącáƺ / y brzemienne ich porozćináƺ.
-Tedy rzekł Házáel : Co? Izali ſługá twój pies / żeby miał ucżynić ták wielką rzecż? Y odpowiedźiał Elizeuƺ : Okázał mi Pán / że ty będźieƺ królem nád Syryją.
-Y odƺedł od Elizeuƺá / á przyƺedł do páná ſwego / który rzekł do niego : Cóż ći powiedźiał Elizeuƺ? A on rzekł : Powiedźiał mi / żebyś pewnie mógł żyć.
-A názájutrz wźiął Házáel kołdrę y zámácżał ją w wodźie / y rozćiągnął ná twárzy jego. Y umárł ( Benádád ) / á Házáel królował miáſto niego.
-A roku piątego Jorámá / ſyná Achábá / królá Izráelſkiego / y Jozáfátá królá Judzkiego / pocżął królowáć Jorám / ſyn Jozáfátá / król Judzki.
-Trzydźieśći y dwá látá miał / gdy królowáć pocżął / á ośm lat królował w Jeruzálemie.
-Ale chodźił drogámi królów Izráelſkich / ſpráwując śię jáko dom Achábowy ; bo córkę Achábowę miał zá żonę / y cżynił złe przed ocżymá Páńſkimi.
-Wƺákże nie chćiał Pán wytráćić Judy / dla Dawidá / ſługi ſwego / jáko mu był powiedźiał / iż mu miał dáć pochodnię miedzy ſynámi jego / po wƺyſtkie dni.
-Zá dni jego odſtąpił Edom / áby nie był pod mocą Judy ; y poſtánowili nád ſobą królá.
-Przetoż przyćiągnął Jorám do Seiru / y wƺyſtkie wozy z nim ; á wſtáwƺy w nocy / poráźił Edomcżyki / którzy go byli otocżyli / y hetmány wozów / ták iż lud ućiekał do námiotów ſwojich.
+Potym Elizeuƺ rzekł do oney niewiáſty / którey był Syná wſkrześił / mówiąc : Wſtań / á idź ty / y dom twój / á bądź gośćiem kędy będźieƺ mogłá bydź : Bo záwołał PAN głodu / y przydźie ná źiemię przez śiedm lat.
+Wſtáłá tedy oná niewiáſtá / y ucżyniłá według ſłowá mężá Bożego / á poƺłá oná / y dom jey : y byłá gośćiem w źiemi Filiſtyńſkiey przez śiedm lat.
+Y ſtáło śię po wyśćiu śiedmi lat że śię wróćiłá oná niewiáſtá z źiemie Filiſtyńſkiey / y poƺłá áby wołáłá ná Królá o dom ſwój y o role ſwoje.
+A ná ten cżás Król rozmawiał z Gezym / ſługą mężá Bożego / mówiąc : Powiedz mi proƺę wƺyſtkie zacne ſpráwy / które cżynił Elizeuƺ.
+A gdy on powiádał Królowi / jáko wſkrześił umárłego ; oto niewiáſtá którey był wſkrześił Syná / záwołáłá ná Królá o dom ſwój / y o rolą ſwoję ; y rzekł Gezy : Królu PANie mój / táć to jeſt niewiáſtá y ten Syn jey / którego wſkrześił Elizeuƺ.
+Y pytał Król niewiáſty / á oná mu powiedźiáłá : Y przydał jey Król komorniká jednego / mówiąc : Przywróć jey wƺyſtko co jey było / y wƺyſtkie dochody z polá / od onego dniá którego opuśćiłá źiemię áż do tąd.
+Potym przyƺedł Elizeuƺ do Dámáƺku / á Benádád Król Syryjſki chorował. Y powiedźiano mu / mówiąc : Przyƺedł tu mąż Boży.
+Y rzekł Król do Házáelá : Weźmi w rękę ſwą upominek / á idź przećiwko mężowi Bożemu / y pytaj śię PAná przezeń / mówiąc : Wſtánęli z tey choroby?
+Przetoż ƺedł Házáel przećiwko niemu / wźiąwƺy upominek w rękę ſwą y ze wƺyſtkich dóbr Dámáſkich brzemion ná cżterdźieśći wielbłądów. Y przyƺedł / á ſtánął przed nim / mówiąc : Syn twój Benádád / Król Syryjſki / poſłał mię do ćiebie / mówiąc : Wſtánęli z tey choroby?
+Y odpowiedźiał mu Elizeuƺ : Idź / powiedz mu : Wprawdźiebyśći mógł żyć : wƺákże okazał mi PAN że pewnie umrze.
+Wtym pokazał mu y ſtáwił twarz ſwoję ſmętną / y płákał mąż Boży.
+Któremu rzekł Házáel : Cżemuż PAN mój płácże? Y odpowiedźiał : Iż wiem co ucżyniƺ złego Synom Izráelſkim. Twierdze ich popaliƺ ogniem / á młodźieńce ich miecżem pomordujeƺ / y dźieći ich poroztrącaƺ / y brzemienne ich poroźćinaƺ.
+Tedy rzekł Házáel : Co? Izali ſługá twój pies / żeby miał ucżynić ták wielką rzecż? Y odpowiedźiał Elizeuƺ : Okazał mi Pan że ty będźieƺ Królem nád Syryją.
+Y odƺedł od Elizeuƺá / á przyƺedł do Páná ſwego / który rzekł do niego : Cóżći powiedźiał Elizeuƺ. A on rzekł : Powiedźiał mi żebyś pewnie mógł żyć.
+A názájutrz / wźiął kołdrę y zmacżał ją w wodźie y rozćiągnął ná twarzy jego : Y umárł : A Házáel Królował miáſto niego.
+A roku piątego Jorámá / Syná Achábá Królá Izráelſkiego / y Jozáfátá Królá Judſkiego / pocżął królowáć Jorám Syn Jozáfátów Król Judſki.
+Trzydźieśći y dwie lećie miał gdy królowáć pocżął : á ośm lat królował w Jeruzalem.
+Ale chodźił drogámi Królów Izráelſkich / ſpráwując śię jáko dom Achábów : Bo córkę Achábowę miał zá żonę / y cżynił złe przed ocżymá Páńſkimi.
+Wƺákże nie chćiał PAN wytráćić Judy / dla Dawidá ſługi ſwego / jáko mu był powiedźiał / iż mu miał dáć pochodnią <i>miedzy</i> Synámi jego po wƺyſtkie dni.
+Zá dni jego odſtąpił Edom / áby nie był pod mocą Judy : y poſtánowili nád ſobą Królá.
+Przetoż przyćiągnął Jorám do Sejiru / y wƺyſtkie wozy z nim : á wſtawƺy w nocy / poráźił Edomcżyki / którzy go byli obtocżyli / y Hetmány wozów ; ták iż lud ućiekał do namiotów ſwojich.
 Wƺákże odſtąpił Edom / áby nie był pod mocą Judy / áż do dniá tego. Odſtąpiło tákże y Lobne onegoż cżáſu.
-A inne ſpráwy Jorámowe / y wƺyſtko co cżynił / izali nie jeſt nápiſáne w kronikách o królách Judzkich?
-Y záſnął Jorám z ojcámi ſwymi / á pogrzebiony jeſt z ojcámi ſwymi w mieśćie Dawidowem ; y królował Ochozyjáƺ / ſyn jego / miáſto niego.
-Roku dwunáſtego Jorámá / ſyná Achábá / królá Izráelſkiego / pocżął królowáć Ochozyjáƺ / ſyn Jorámá / królá Judzkiego.
-We dwudźieſtu y dwu látách był Ochozyjáƺ / gdy królowáć pocżął / á rok jeden królował w Jeruzálemie ; á imię mátki jego było Atálijá / córká Amrego / królá Izráelſkiego.
-Ten chodźił drogą domu Achábowego / y cżynił złe przed ocżymá Páńſkimi / jáko y dom Achábowy ; bo był źięćiem domu Achábowego.
-Przetoż wychádzał z Jorámem / ſynem Achábowym / ná wojnę przećiw Házáelowi / królowi Syryjſkiemu / do Rámot Gáláádſkiego ; ále poráźili Syryjcżycy Jorámá.
-A ták wróćił śię król Jorám / áby śię lecżył w Jezreelu ná rány / które mu byli zádáli Syryjcżycy w Rámáćie / gdy wálcżył z Házáelem / królem Syryjſkim. A Ochozyjáƺ / ſyn Jorámá / królá Judzkiego / przyjechał náwiedzáć Jorámá / ſyná Achábowego / do Jezreelá ; bo tám chorował.
+A inne ſpráwy Jorámowe / y wƺyſtko co cżynił / izali nie jeſt nápiſáno w Kronikách o Królách Judſkich.
+Y záſnął Jorám z Ojcy ſwymi / á pogrzebiony jeſt z Ojcy ſwymi w mieśćie Dawidowym : y królował Ochoziaƺ Syn jego miáſto niego.
+Roku dwunaſtego Jorámá Syná Achábá Królá Izráelſkiego / pocżął królowáć Ochoziaƺ / Syn Jorámá Królá Judſkiego.
+We dwudźieſtu y dwu lećiech był Ochoziaƺ / gdy królowáć pocżął : á rok jeden królował w Jeruzalem : á imię mátki jego było Atália córká Amrego Królá Izráelſkiego.
+Ten chodźił drogą domu Achábowego / y cżynił złe przed ocżymá Páńſkimi jáko y dom Achábów / bo był źięćiem domu Achábowego.
+Przetoż wychadzał z Jorámem / Synem Achábowym ná wojnę przećiw Házáelowi królowi Syryjſkiemu / do Rámot Gáláádſkiego : ále poráźili Syryjcżycy Jorámá.
+A ták wróćił śię Król Jorám áby śię lecżył w Jezreelu ná rány które mu byli zádáli Syryjcżycy w Rámáćie / gdy walcżył z Házáelem Królem Syryjſkim : A Ochoziaƺ Syn Jorámá Królá Judſkiego przyjáchał náwiedzáć Jorámá Syná Achábowego do Jezreelá / bo <i>tám</i> chorował.


### PR DESCRIPTION
w.11."wtym" raczej powinno być osobno - porównując z innymi miejsami rozpoczynającymi akapit, jest tu pusta przestrzeń sugrująca spację, 1660 też ma spację, można próbować porównać z KJV; 1632 ma też nie wyraźny ukośnik; 1660 już ma wyraźny - zostawiłem ukośnik, podobnie w.21.
w.13. 1632 "rzecz", 1660 "rzecż"; zostawiłem jak w 1660. podobnie w.15 "zmacżał"; w.16;17. "pocżął", w.27.
w.14;23. lepiej pasuje "?" zmiast kropki.