### PR TITLE
Izaj.23,12.

### DIFF
--- a/2023/23-esa/23.txt
+++ b/2023/23-esa/23.txt
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+
+
+
+Y rzekł : Już śię nie będźieƺ więcey weſeliłá / ty zgwałcona Pánno / córko Sydońſka. Powſtań / przepraw śię do Citim : <i>lecż</i> y tám nie będźieƺ miáłá odpocżynku.
+
+
+
+
+
+


### PR DESCRIPTION
Syońſka -> Sydońſka (KJV, tekst masorecki)

Literówka w polskim wydaniu. Zarówno KJV (zrzuty ekranu), jak i tekst masorecki mają w w.2 i 12 ten sam wyraz:
KJV: Zidon
Tekst masorecki: "צידון"
![image](https://github.com/user-attachments/assets/2dff3f99-46a6-4fd6-93a4-d7bd54a50e24)
![image](https://github.com/user-attachments/assets/62b7a05f-7f3a-4523-846a-575a30dfc4fd)

wersety w języku hebrajskim:
2 דמו ישבי אי סחר צידון עבר ים מלאוך׃
12 ויאמר לא תוסיפי עוד לעלוז המעשקה בתולת בת צידון כתיים קומי עברי גם שם לא ינוח לך׃

Źródło:
KJV: https://www.kingjamesbibleonline.org/Isaiah_23_1611/
Tekst masorecki: https://wordproject.org/bibles/he/23/23.htm#0

-------
Czy tego typu zamiany aplikować na bieżąco czy zbiorczo spisywać listę poprawek na przyszłość?