### PR TITLE
Dzie.11,23.

### DIFF
--- a/1632/44-act/11.txt
+++ b/1632/44-act/11.txt
@@ -20,7 +20,7 @@ Lecż oni / którzy byli rozproƺeni przed utrapieniem / które śię ſtáło d
 A byli niektórzy z nich mężowie z Cypru y z Cyreny / którzy przyƺedƺy do Antiochiey / mówili Grekom / opowiádájąc PAná JEzuſá.
 Y byłá z nimi ręká PAńſka / á wielki pocżet uwierzywƺy / náwróćił śię do PAná.
 Y przyƺłá o nich wieść do uƺu Zboru który był w Jeruzalem : y poſłáli Bárnábaƺá / áby ƺedł áż do Antyochiey.
-Który tám przyƺedƺy / á ujrzáwƺy łáſkę Bożą / urádował śię : y nápominał wƺyſtkich / áby w przedśięwźięćiu ſercá trwáli przy PAnu.
+Który tám przyƺedƺy / á ujrzawƺy łáſkę Bożą / urádował śię : y nápominał wƺyſtkich / áby w przedśięwźięćiu ſercá trwáli przy PAnu.
 Abowiem był mąż dobry / y pełen Duchá Świętego / y wiáry. Y przybyło wielkie mnóſtwo PAnu.
 Potym odƺedł Bárnábaƺ do Tárſu / áby ƺukał Saulá : á ználazƺy go / przyprowádźił go do Antyochiey.
 Y báwili śię przez cáły rok przy onym Zborze / y ucżyli mnóſtwo wielkie : á napierwey w Antyochiey ucżniowie názwáni ſą Chrześćiány.


### PR DESCRIPTION
por. 1660 i 1606.
Zauważyłem że to raczej ogólna zasada że końcówka wyrazu "awszy" jest pisana bez kreski nad literą "a".