### PR TITLE
Dzie.17,2;7.

### DIFF
--- a/1879/44-act/17.txt
+++ b/1879/44-act/17.txt
@@ -1,10 +1,10 @@
 A przeszedłszy Amfipolim i Apoloniję przyszli do Tesaloniki, gdzie była bóżnica żydowska.
-Tedy Paweł według zwyczaju swego wszedł do nich, a przez trzy sabaty kazał im z Pisma.
+Tedy Paweł według zwyczaju swego wszedł do nich, a przez trzy sabaty kazał im z Pisma;
 Wywodząc i pokazując to, że Chrystus miał cierpieć i powstać od umarłych, a iż ten Jezus jest Chrystusem, którego ja wam opowiadam.
 I uwierzyli niektórzy z nich, a przyłączyli się do Pawła i do Syli, i wielkie mnóstwo nabożnych Greków, i niewiast przedniejszych nie mało.
 Ale Żydowie, którzy nie uwierzyli, zdjęci zazdrością, przywziąwszy do siebie niektórych lekkomyślnych i złych mężów, a zebrawszy kupę uczynili rozruch w mieście, a naszedłszy na dom Jazona, szukali ich, aby ich wywiedli przed lud.
 A nie znalazłszy ich, ciągnęli Jazona i niektórych braci do przełożonych miasta, wołając: Oto ci, którzy wszystek świat wzruszyli, i tu też przyszli;
-Które przyjął Jazon: a ci wszyscy czynią przeciwko dekretom cesarskim, powiadając, iż jest inszy król. Jezus.
+Które przyjął Jazon: a ci wszyscy czynią przeciwko dekretom cesarskim, powiadając, iż jest inszy król, Jezus.
 A tak wzburzyli pospólstwo i przełożonych miasta, którzy to słyszeli.
 Ale oni wziąwszy słuszną sprawę od Jazona i od innych, puścili je.
 A bracia wnet w nocy wysłali i Pawła i Sylę do Berei; którzy tam przyszedłszy, weszli do bóżnicy żydowskiej.


### PR DESCRIPTION
![20250227_163956](https://github.com/user-attachments/assets/292ac039-87ae-4cc7-a0e5-07fa9a062189)
![20250227_164905(0)](https://github.com/user-attachments/assets/8f9f1e3e-8fab-41f9-96c2-21e454ffbc3e)

w.7: W skanie przecinek niewidoczny, ale reprinty mają wyraźnie przecinek, z kolei jeśli chodzi o oryginał z 1879 to też tam widnieje przecinek (jestem w posiadaniu takiego wydania i zrobiłem zdjęcie pokazujące poprawiany fragment - pierwsze zdjęcie z góry pochodzi z wydania z 1879 roku).