### PR TITLE
1 Moj.24,3;48.

### DIFF
--- a/1632/01-gen/24.txt
+++ b/1632/01-gen/24.txt
@@ -1,6 +1,6 @@
 A Abráhám był ſtáry y podeƺły w lećiech / á Pan błogoſłáwił mu we wƺyſtkiem.
 Tedy rzekł Abráhám do ſtárƺego ſługi ſwego w domu ſwym / który wƺyſtkiem rządźił co miał : połóż / proƺę / rękę twoję pod biodrę moję /
-A poprzyśięgnę ćię przez Páná / Bogá Niebá / y Bogá źiemie / Abyś nie brał żony Synowi memu z córek Chánánejſkich / miedzy którymi ja mieƺkam :
+A poprzyśięgę ćię przez Páná / Bogá Niebá / y Bogá źiemie / Abyś nie brał żony Synowi memu z córek Chánánejſkich / miedzy którymi ja mieƺkam :
 Ale pójdźieƺ do źiemie mojey / y do rodźiny mojey / á <i>z támtąd</i> weźmieƺ żonę Izáákowi Synowi memu.
 Tedy mu rzekł ſługá : A jesliby ſnadź nie chćiáłá niewiáſtá <i>oná</i> iść że mną do tey źiemie / mamze odprowádźić ſyná twego do źiemie z któreyś ty wyƺedł?
 Y rzekł mu Abráhám : Strzeż śię ábyś tám záśię nie záprowadzał Syná mego.
@@ -45,7 +45,7 @@ A onáby rzekłá do mnie / y ty pij / náczerpam też y wielbłądom twojim / t
 Niżlim ja tedy przeſtał mówić w ſercu ſwym / oto Rebeká wychodźiłá nioſąc wiádro ſwe ná rámieniu ſwym / y przyƺłá do ſtudni / á czerpáłá / któreym rzekł / Daj mi pić proƺę.
 Oná tedy prętko złożywƺy wiádro z śiebie rzekłá / pij / owƺem y wielbłądy twoje nápoję. Y piłem / nápojiłá też y wielbłądy.
 Y pytałem jey / mówiąc : Czyjáś ty córká? y odpowiedźiáłá : <i>Jeſtem</i> córká Bátuelá ſyná Nachorowego / którego mu urodźiłá Melchá / tedym włożył náuƺnicę ná twarz jey / y mánelle ná ręce jey.
-Zátym pokłoniwƺy śię dałem chwałę Pánu / y błogoſłáwiłem Pánu / Bogu Páná mego Abráhámá / który mię prowádźił drogą práwą / ábym wźiął córkę brátá Páná mego ſynowi jego
+Zátym pokłoniwƺy śię dałem chwałę Pánu / y błogoſłáwiłem Pánu / Bogu Páná mego Abráhámá / który mię prowádźił drogą práwą / ábym wźiął córkę brátá Páná mego ſynowi jego.
 Przetoż teraz jesli chcećie uczynić miłośierdźie y prawdę z Pánem mojim / oznájmijćie mi : á jesli nie / powiedzćie mi też / żebym śię obróćił ná práwo álbo ná lewo.
 Tedy odpowiedźiał Lában y Bátuel / mówiąc : Od PANA tá rzecz wyƺłá / my tobie w nicżym przecżyć niemożymy.
 Oto Rebeká przed tobą : weźmi <i>ją,</i> á idź : á niech będźie żoną ſyná Páná twego / jáko rzekł PAN.


### PR DESCRIPTION
Niejednolita pisownia "przyciągnę*"/"przyciągne*" dla 1632; np. przyciągnęli. conajmniej jedno miejsce w którym 1660 poprawia na wersję z "ę". podobnie może być z słowami "odciągnęli", "wyciągnęli", "ćiągnęli". Możliwe że warto też przeszukać inne słowa zawierające "nęli", "neli" lub "gnęli", "nęli". Współcześnie poprawna pisownia to ta z "ę".
Pojawia się zatem pytanie - czy w tekście cyfrowym 1632 chcemy mieć tak jak w skanie niejednolitość, czy ujednolicać do wersji z "ę"?