### PR TITLE
2 Król.10.

### DIFF
--- a/1632/12-reg/10.txt
+++ b/1632/12-reg/10.txt
@@ -1,36 +1,36 @@
-A miał Acháb śiedmdźieśiąt ſynów w Sámáryi. Y nápiſał Jehu liſt / á poſłał go do Sámáryi do kśiążąt Jezreelſkich / y do ſtárƺych / y do tych / którzy wychowywáli ſyny Achábowe / w te ſłowá :
-Skoro was dojdźie ten liſt / gdyż u was ſą ſynowie páná wáƺego / y u was wozy / y konie / y miáſto obronne / y rynƺtunek ;
-Obierzćież nájgodniejƺego y nájſpoſobniejƺego z ſynów páná wáƺego / á poſádźćie ná ſtolicy ojcá jego / y wálcżćie o dom páná wáƺego.
-Ale śię oni bárzo bojąc rzekli : Oto dwáj królowie nie oſtáli śię przed nim / á jákoż my śię oſtoimy?
-A ták poſłał ten / który był ſpráwcą domu / y ten / który był ſpráwcą miáſtá / y ſtárśi / y ći / którzy wychowywáli ſyny królewſkie / do Jehu / mówiąc : Słudzyśmy twoi / á co nam rozkáżeƺ / ucżynimy. Nie poſtánowiemy królá żádnego ; co dobrego jeſt w ocżách twojich / cżyń.
-Y nápiſał do nich liſt drugi / mówiąc : Jeſliśćie moi / á głoſu mego ſłucháćie / weźmijćież głowy ſynów páná wáƺego / á przyjdźćie do mnie jutro o tym cżáśie do Jezreel. A ſynów królewſkich było śiedmdźieśiąt mężów u nájprzedniejƺych w mieśćie / którzy je wychowywáli.
-A gdy ich liſt doƺedł / wźiąwƺy ſyny królewſkie / pobili onych śiedmdźieśiąt mężów / á ſkłádƺy głowy ich do koƺów / poſłáli je do niego do Jezreelá.
-Y przyƺedł poſeł / który mu oznájmił / mówiąc : Przynieśiono głowy ſynów królewſkich. A on rzekł : Skłádźćie je ná dwie kupie u wejśćiá bramy áż do poránku.
-A gdy ráno wyƺedł / ſtánął / y rzekł do wƺyſtkiego ludu : Spráwiedliwiśćie wy. Otom śię ja ſprzyśiągł przećiwko pánu memu / y zábiłem go ; ále te wƺyſtkie któż pobił?
-Wiedzćież teraz / że nie upádło prózno żádne z ſłów Páńſkich ná źiemię / które mówił Pán przećiwko domowi Achábowemu / gdyż ucżynił Pán / co był powiedźiał przez ſługę ſwego Elijáƺá.
-A ták pobił Jehu wƺyſtkie / którzy pozoſtáli z domu Achábowego w Jezreelu / y wƺyſtkie nájprzedniejƺe jego / y przyjáćiele jego / y kápłány jego / ták iż nie zoſtáwił po nim żádnego żywego.
-Potem wſtáwƺy odƺedł / y pojechał do Sámáryi. A gdy był u domu / gdźie páſterze ſtrzygáli owce ná drodze /
-Tedy Jehu ználázł bráći Ochozyjáƺá królá Judzkiego / y rzekł : Któśćie wy? Y odpowiedźieli : Bráćiaśmy Ochozyjáƺowi / á idźiemy / ábyſmy pozdrowili ſyny królewſkie / y ſyny królowej.
-Tedy rzekł : Pojmájćie je żywo. Y pojmáli je żywo / y pobili je u ſtudni onegoż domu / gdźie ſtrzygáno owce / cżterdźieſtu y dwu mężów / y nie zoſtáwił żádnego z nich.
-Potem odjecháwƺy z támtąd / tráfił Jonádábá / ſyná Rechábowego / idącego przećiwko ſobie / á pozdrowił go y rzekł do niego : Jeſtże ſerce twoje ƺcżere / jáko jeſt ſerce moje z ſercem twojim? Y odpowiedźiał mu Jonádáb : Jeſt. A jeſt? rzekł Jehu / dájże mi rękę twoję. Tedy mu dał rękę ſwą ; y kázał mu wśiąść do śiebie ná wóz /
-Y rzekł : Jedź ze mną / á przypátrz śię gorliwośći mojey zá Páná. A ták wiózł go ná woźie ſwoim.
-A gdy przyjechał do Sámáryi / bił wƺyſtkie / którzy byli pozoſtáli z domu Achábowego w Sámáryi / y wytráćił je według ſłowá Páńſkiego / które mówił do Elijáƺá.
-Zátem zebrał Jehu wƺyſtek lud / y rzekł do niego : Acháb ſłużył Báálowi máło / Jehu mu będźie ſłużył więcey.
-Przetoż teraz wƺyſtkich proroków Báálowych / wƺyſtkich ſług jego / y wƺyſtkich kápłanów jego / zwołájćie do mnie áż do jednego ; ábowiem ofiárę wielką będę ſpráwował Báálowi. Ktoby śię kolwiek nie ſtáwił / nie zoſtánie żyw. A to Jehu chytrze cżynił / chcąc wytráćić chwálce Báálowe.
-Nádto rzekł Jehu : Zápowiedzćie święto Báálowi. Y obwołáno je.
-Y rozeſłał Jehu do wƺyſtkiego Izráelá. Y zeƺli śię wƺyſcy chwálcy Báálowi / ták że nie zoſtał żáden / któryby nie przyƺedł. Y weƺli do kośćiołá Báálowego / á nápełniony był dom Báálowy od końcá áż do końcá.
-Tedy rzekł temu / który był nád ƺátámi : Wynieś ƺáty wƺyſtkim chwálcom Báálowym. Y wynióſł im ƺáty.
-Zátem wƺedł Jehu y Jonádáb / ſyn Rechábowy / do domu Báálowego / y rzekł chwálcom Báálowym : Dowiedzćie śię / á obácżćie / by ſnadź nie był kto z wámi z chwálców Páńſkich / oprócż ſámych chwálców Báálowych.
-A ták weƺli / áby ſpráwowáli ofiáry / y cáłopalenia. Ale Jehu ſporządźił był ſobie ná dworze ośmdźieśiąt mężów / którym był rzekł : Jeſliby kto uƺedł z ludu tego / który ja podáwám w ręce wáƺe / duƺá wáƺá będźie zá duƺę onego.
-A gdy śię dokońcżyły ofiáry cáłopalenia / rzekł Jehu żołnierzom y rotmiſtrzom ſwym : Wnijdźćie / á pomordujćie je / áby żáden nie uƺedł. A ták pomordowáli je oſtrzem miecżá / y rozrzućili je żołnierze y rotmiſtrze ; potem odeƺli do káżdego miáſtá / gdźie był dom Báálowy.
-A wyrzućiwƺy báłwány z domu Báálowego / popálili je.
-Obálili też ſłup Báálowy / obálili y dom jego / á ucżynili z niego wychody / áż do tego cżáſu.
+A miał Acháb śiedmdźieśiąt Synów w Sámáryjey. Y nápiſał Jehu liſt / á poſłał <i>go</i> do Sámáryjey do Kśiążąt Jezreelſkich / y do ſtárƺych / y do tych którzy wychowywáli <i>Syny</i> Achábowe / w te ſłowá :
+Skoro was dojdźie ten liſt : gdyż u was ſą Synowie Páná wáƺego / y u was wozy / y konie / y miáſto obronne / y rynƺtunek :
+Obierzćież nagodniejƺego y naſpoſobniejƺego z ſynów Páná wáƺego / á poſadźćie ná ſtolicy Ojcá jego / y walcżćie o dom Páná wáƺego.
+Ale śię oni bárzo bojąc / rzekli : Oto dwá Królowie nie oſtali śię przed nim ; á jákoż my śię oſtojimy?
+A ták poſłał ten który był ſprawcą domu / y ten który był ſprawcą miáſtá / y ſtárƺy / y ći którzy wychowywáli <i>Syny królewſkie</i> do Jehu / mówiąc ; Słudzyſmy twoji : á co nam rozkażeƺ ucżyniemy. Nie poſtánowiemy Królá żadnego : Co dobrego jeſt w ocżách twojich / cżyń.
+Y nápiſał do nich liſt drugi / mówiąc : Jeſliśćie moji / á głoſu mego ſłuchaćie / weźmićież głowy Synów Páná wáƺego / á przydźćie do mnie jutro o tym cżáśie do Jezreel. ( A Synów królewſkich było śiedmdźieśiąt mężów / u naprzedniejƺych w mieśćie / którzy je wychowywáli. )
+A gdy jch liſt doƺedł / wźiąwƺy Syny Królewſkie / pobili onych śiedmdźieśiąt mężów ; á ſkładƺy głowy ich do koƺów / poſłáli je do niego do Jezreelá.
+Y przyƺedł poſeł / który mu oznájmił / mówiąc : Przynieśiono głowy Synów Królewſkich : á <i>on</i> rzekł : Skłádźćie je ná dwie kupie u weśćia bramy áż do poránku.
+A gdy ráno wyƺedł / ſtánął / y rzekł do wƺyſtkiego ludu : Spráwiedliwiśćie wy. Otom śię ja zprzyśiągł przećiwko Pánu memu / y zábiłem go. Ale te wƺyſtkie któż pobił?
+Wiedzćież teraz / że nie upádło prózno <i>żadne</i> z ſłów Páńſkich ná źiemię / które mówił PAN przećiwko domowi Achábowemu ; gdyż ucżynił PAN / co był powiedźiał przez ſługę ſwego Eliaƺá.
+A ták pobił Jehu wƺyſtkie którzy pozoſtáli z domu Achábowego w Jezreelu / y wƺyſtkie naprzedniejƺe jego / y przyjaćiele jego y kápłany jego : ták iż nie zoſtáwił po nim żadnego żywego.
+Potym wſtawƺy odƺedł / y pojáchał do Sámáryjey. A <i>gdy</i> był u domu gdźie páſterze ſtrzygáli owce / ná drodze :
+Tedy Jehu ználazł bráćią Ochoziaƺá Królá Judſkiego / y rzekł : Któśćie wy? y odpowiedźieli : Bráćiaſmy Ochoziaƺowi / á idźiemy / ábyſmy pozdrowili Syny Królewſkie / y Syny Królowey.
+Tedy rzekł : Pojimajćie je żywo. Y pojimano je żywo / y pobili je u ſtudnie onegoż domu / gdźie ſtrzygano owce / cżterdźieſtu y dwu mężów : y nie zoſtáwił żadnego z nich.
+Potym odjáchawƺy z támtąd / tráfił Jonádábá / Syná Rechábowego idącego przećiwko ſobie / á pozdrowił go y rzekł do niego : Jeſtże ſerce twoje ƺcżere jáko jeſt ſerce moje z ſercem twojim? Y odpowiedźiał mu Jonádáb : Jeſt. A jeſt? <i>rzekł Jehu</i> : Dajże mi rękę twoję : Tedy mu dał rękę ſwą : y kazał mu wśieść do śiebie ná wóz.
+Y rzekł / Jedź ze mną / á przypátrz śię gorliwośći mojey zá PANA. A ták wiózł go ná woźie ſwojim.
+A gdy przyjáchał do Sámáryjey bił wƺyſtkie którzy byli pozoſtáli <i>z domu</i> Achábowego w Sámáryjey / y wytráćił je według ſłowá Páńſkiego / które mówił do Eliaƺá.
+Zátym zebrał Jehu wƺyſtek lud / y rzekł do niego ; Acháb ſłużył Báálowi máło : Jehu mu będźie ſłużył więcey.
+Przetoż teraz wƺyſtkich proroków Báálowych / wƺyſtkich ſług jego / y wƺyſtkich Kápłanów jego / zwołajćie do mnie / áż do jednego : Abowiem ofiárę wielką będę ſpráwował Báálowi. Ktoby śię kolwiek nie ſtáwił / nie zoſtánie żyw : A <i>to</i> Jehu chytrze cżynił / chcąc wytráćić chwalce Báálowe.
+Nád to rzekł Jehu ; Zápowiedzćie święto Báálowi ; Y obwołano <i>je</i>.
+Y rozeſłał Jehu do wƺyſtkiego Izráelá : Y zeƺli śię wƺyſcy chwalcy Báálowi : ták / że nie zoſtał żaden któryby nie przyƺedł : Y weƺli do kośćiołá Báálowego / á nápełniony był dom Báálów / od końcá áż do końcá.
+Tedy rzekł temu który był nád ƺátámi : Wynieś ƺáty wƺyſtkim chwalcom Báálowym : Y wynióſł im ƺáty.
+Zátym wƺedł Jehu y Jonádáb Syn Rechábów do domu Báálowego / y rzekł chwalcom Báálowym : Dowiedzćie śię / á obacżćie / by ſnadź nie był kto z wámi z chwalców Páńſkich / oprócż ſámych chwalców Báálowych.
+A ták weƺli áby ſpráwowáli Ofiáry / y cáłopalenia. Ale Jehu ſporządźił był ſobie ná dworze ośmdźieśiąt mężów / którym był rzekł : Jeſliby kto uƺedł z ludu tego / który ja podawam w ręcę wáƺe / duƺá wáƺá będźie zá duƺę onego.
+A gdy śię dokońcżyły Ofiáry cáłopalenia / rzekł Jehu żołnierzom y Rotmiſtrzom ſwym : Wnidźćie / á pomordujćie je / <i>aby</i> żaden nie uƺedł. A ták pomordowáli je oſtrzem miecżá / y rozrzućili <i>je</i> żołnierze y rotmiſtrze : Potym odeƺli do káżdego miáſtá / <i>gdźie był</i> dom Báálów.
+A wyrzućiwƺy báłwany / z domu Báálowego / popalili je.
+Obálili też ſłup Báálów / obálili y dom jego : á ucżynili z niego wychody áż do tego cżáſu.
 A ták wygłádźił Jehu Báálá z Izráelá.
-Wƺákże od grzechów Jeroboámá / ſyná Nábátowego / który do grzechu przywiódł Izráelá / nie odſtąpił Jehu / áni opuśćił ćielców złotych / które były w Betel / y które były w Dán.
-Tedy rzekł Pán do Jehu : Poniewáżeś śię pilnie ſtárał / ábyś ucżynił / co dobrego jeſt w ocżách mojich / według wƺyſtkiego / co było w ſercu mojim / ucżyniłeś domowi Achábowemu : ſynowie twoi áż do cżwártego pokolenia śiedźieć będą ná ſtolicy Izráelſkiej.
-Ale Jehu nie ſtrzegł tego / áby chodźił w zakonie Páná / Bogá Izráelſkiego / ze wƺyſtkiego ſercá ſwego / áni odſtąpił od grzechów Jeroboámowych / który do grzechu przywiódł Izráelá.
-W one dni pocżął Pán umniejƺáć Izráelá : bo je poráźił Házáel po wƺyſtkich gránicách Izráelſkich :
-Od Jordánu áż ná wſchód ſłońcá / wƺyſtkę źiemię Gáláádſką / Gádową / y Rubenową / y Mánáſeſową od Aroer / które jeſt u potoku Arnon / y Gáláád / y Báſán.
-Ale oſtátek ſpráw Jehu / y wƺyſtko / co cżynił / y wƺyſtká moc jego / ázaż tego nie nápiſano w kronikách królów Izráelſkich?
-Y záſnął Jehu z ojcámi ſwymi / y pochowáli go w Sámáryi ; á królował Joácház / ſyn jego / miáſto niego.
-A cżás / którego królował Jehu nád Izráelem w Sámáryi / było dwádźieśćiá y ośm lat.
+Wƺákże <i>od</i> grzechów Jeroboámá / Syná Nábátowego / który do grzechu przywiódł Izráelá / nie odſtąpił Jehu / áni opuśćił ćielców złotych / które były w Bethel / y które <i>były</i> w Dán.
+Tedy rzekł PAN do Jehu : Ponieważeś śię pilnie ſtárał / ábyś ucżynił co dobrego jeſt w ocżách mojich / według wƺyſtkiego / co było w ſercu mojim ucżyniłeś domowi Achábowemu : Synowie twoji áż do cżwartego pokolenia / śiedźieć będą ná ſtolicy Izráelſkiey.
+Ale Jehu nie ſtrzegł <i>tego</i> / áby chodźił w zakonie PANA Bogá Izráelſkiego / ze wƺyſtkiego ſercá ſwego ; áni odſtąpił od grzechów Jeroboámowych / który do grzechu przywiódł Izráelá.
+W one dni / pocżął PAN umniejƺáć Izráelá : bo je poráźił Házáel / po wƺyſtkich gránicách Izráelſkich.
+Od Jordanu áż ná wſchód ſłońcá : wƺyſtkę źiemię Gáláádſką / Gádowę / y Rubenowę / y Mánáſſeſſowę od Aroer które jeſt u potoká Arnon / y Gáláád y Báſán.
+Ale oſtátek ſpraw Jehu / y wƺyſtko co cżynił / y wƺyſtká moc jego / ázaż tego nie nápiſano w Kronikách Królów Izráelſkich.
+Y záſnął Jehu z Ojcy ſwymi / y pochowáli go w Sámáryjey / á królował Joácház Syn jego miáſto niego.
+A cżás którego królował Jehu nád Jeruzalem w Sámáryjey / <i>było</i> dwádźieśćiá y ośm lat.


### PR DESCRIPTION
w.8. 1660 ma ":" po "rzekł" - zostawiłem ":"
w.13. można zamienić "y" -> "Y"
w.34. 1660 ma na końcu "?"
w.36. błąd w tłumaczeniu "Jeruzalem" - zaadresowane w #2635 