### PR TITLE
2 Król.15.

### DIFF
--- a/1632/12-reg/15.txt
+++ b/1632/12-reg/15.txt
@@ -1,38 +1,38 @@
-Roku dwudźieſtego y śiódmego Jeroboámá / królá Izráelſkiego / królował Azáryjáƺ / ſyn Amázyjáƺá / królá Judzkiego.
-Szeſnaśćie mu lat było / gdy pocżął królowáć / á pięćdźieśiąt y dwá látá królował w Jeruzálemie. Imię mátki jego było Jechelijá z Jeruzálemu.
-Ten cżynił / co dobrego jeſt w ocżách Páńſkich / według wƺyſtkiego / jáko cżynił Amázyjáƺ / oćiec jego.
+Roku dwudźieſtego y śiódmego / Jeroboámá Królá Izráelſkiego / królował Azáryaƺ Syn Amázyaƺá Królá Judſkiego.
+Szeſnaśćie mu lat było / gdy pocżął królowáć / á pięćdźieśiąt y dwie lećie królował w Jeruzalem : Imię mátki jego <i>było</i> Jechelia z Jeruzalem.
+Ten cżynił co dobrego jeſt w ocżách PAŃſkich / według wƺyſtkiego / jáko cżynił Amázyaƺ Oćiec jego.
 Wƺákże wyżyny nie były znieśione : jeƺcże lud ofiárował y kádźił po wyżynách.
-Y záráźił Pán królá / á był trędowátym áż do śmierći ſwej / y mieƺkał w domu oſobnym ; przetoż Joátám / ſyn królewſki / rządźił domem / ſądząc lud źiemi.
-A inne ſpráwy Azáryjáƺowe / y wƺyſtko co cżynił / ázaż tego nie zápiſáno w kronikách o królách Judzkich?
-Y záſnął Azáryjáƺ z ojcámi ſwymi / á pochowano go z ojcámi jego w mieśćie Dawidowem ; á królował Joátám / ſyn jego / miáſto niego.
-Roku trzydźieſtego y óſmego Azáryjáƺá / królá Judzkiego / królował Zácháryjáƺ / ſyn Jeroboámowy / nád Izráelem w Sámáryi ƺeść mieśięcy.
-Y cżynił złe przed ocżymá Páńſkimi / jáko cżynili ojcowie jego / nie odſtępując od grzechów Jeroboámá / ſyná Nábátowego / który przywiódł do grzechu Izráelá.
-Y ſprzyśiągł śię przećiw niemu Sellum / ſyn Jábeſowy / y ránił go przed ludem / y zábił go / á królował miáſto niego.
-A inne ſpráwy Zácháryjáƺowe / oto ſą nápiſáne w kronikách o królách Izráelſkich.
-Toć jeſt ono ſłowo Páńſkie / które powiedźiał do Jehu / mówiąc : Synowie twoi do cżwártego pokolenia będą śiedźieli ná ſtolicy Izráelſkiej. Y ták śię ſtáło.
-Tedy Sellum / ſyn Jábeſowy / królował roku trzydźieſtego y dźiewiątego roku Uzyjáƺá / królá Judzkiego / á królował przez jeden mieśiąc w Sámáryi.
-Bo przyćiągnąwƺy Mánáchem / ſyn Gády / z Terſy / á przyƺedƺy do Sámáryi / poráźił Sellumá / ſyná Jábeſowego w Sámáryi / á zábiwƺy go / królował miáſto niego.
-A inne ſpráwy Sellumowe / y ſprzyśiężenie jego / którem śię był ſprzyśiągł / oto zápiſáne w kronikách o królách Izráelſkich.
-Tedy dobył Mánáchem miáſtá Táfſy / y pobił wƺyſtkie / którzy w nim byli / y wƺyſtkie gránice jego od Terſy ; przeto / że mu nie otworzyli / pomordował je / y wƺyſtkie brzemienne w nim porozćinał.
-Roku trzydźieſtego y dźiewiątego Azáryjáƺá / królá Judzkiego / królował Mánáchem / ſyn Gády / nád Izráelem dźieśięć lat w Sámáryi.
-Y cżynił złe przed ocżymá Páńſkimi / nie odſtępując od grzechów Jeroboámá / ſyná Nábátowego / który do grzechu przywodźił Izráelá po wƺyſtkie dni ſwoje.
-A gdy wyćiągnął Ful / król Aſſyryjſki / przećiw źiemi Izráelſkiej / dał Mánáchem Fulowi tyśiąc tálentów ſrebrá / áby mu był ná pomocy ku umocnieniu króleſtwá w rękách jego.
-Y ułożył Mánáchem podátek ná Izráelá / ná wƺyſtkie co nájbogátƺe / áby dáwáli królowi Aſſyryjſkiemu / po pięćdźieśiąt ſyklów ſrebrá / káżdy z oſobná ; y wróćił śię król Aſſyryjſki / á nie báwił śię tám w oney źiemi.
-A inne ſpráwy Mánáchemowe / y cokolwiek cżynił / nápiſáne ſą w kronikách o królách Izráelſkich.
-Y záſnął Mánáchem z ojcámi ſwymi / á królował Fácejáƺ / ſyn jego / miáſto niego.
-Roku pięćdźieśiątego Azáryjáƺá / królá Judzkiego / królował Fácejáƺ / ſyn Mánáchemowy / nád Izráelem w Sámáryi dwá látá.
-Y cżynił złe przed ocżymá Páńſkimi / nie odſtępując od grzechu Jeroboámá / ſyná Nábátowego / który przywiódł do grzechu Izráelá.
-Tedy śię zbuntował przećiwko niemu Fácejáƺ / ſyn Romelijáƺá / hetmán jego / y zábił go w Sámáryi w páłácu domu królewſkiego / z Argobem y z Aryjáƺem / májąc z ſobą pięćdźieśiąt mężów Gáláádcżyków / á zábiwƺy go królował miáſto niego.
-A inne ſpráwy Fácejáƺowe y wƺyſtko co cżynił / oto nápiſano w kronikách o królách Izráelſkich.
-Roku pięćdźieśiątego y wtórego Azáryjáƺá / królá Judzkiego / królował Fácejáƺ / ſyn Romelijáƺá / nád Izráelem w Sámáryi dwádźieśćiá lat.
-Y cżynił złe przed ocżymá Páńſkimi / nie odſtępując od grzechów Jeroboámá / ſyná Nábátowego / który przywiódł do grzechu Izráelá.
-Zá dni Fácejáƺá / królá Izráelſkiego / przyćiągnął Teglát Fáláſer / król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kiedes / y Azor / y Gáláád / y Gálileę / wƺyſtkę źiemię Neftáli / á przenióſł obywátele jey do Aſſyryi.
-Tedy śię zbuntował Ozeáƺ / ſyn Eli / przećiw Fácejáƺowi / ſynowi Romelijáƺowemu / á rániwƺy go / zábił go / y królował miáſto niego roku dwudźieſtego Joátámá / ſyná Uzyjáƺowego.
-A inne ſpráwy Fácejáƺowe / y wƺyſtko co cżynił / oto zápiſáno w kronikách o królách Izráelſkich.
-Roku wtórego Fácejáƺá / ſyná Romelijáƺowego / królá Izráelſkiego królował Joátám / ſyn Uzyjáƺá / królá Judzkiego.
-Dwádźieśćiá y pięć lat miał / gdy królowáć pocżął / á ƺeſnaśćie lat królował w Jeruzálemie. Imię mátki jego Jeruſá / córká Sádokowá.
-Y cżynił / co dobrego jeſt przed ocżymá Páńſkimi ; według wƺyſtkiego / co cżynił Uzyjáƺ / oćiec jego / poſtępował.
-Wƺákże wyżyny nie były znieśione ; jeƺcże lud ofiárował y kádźił ná wyżynách. Tenże zbudował bramę nájwyżƺą domu Páńſkiego.
-A inne ſpráwy Joátámowe / y wƺyſtko co cżynił / zápiſáne w kronikách o królách Judzkich.
-Zá onych dni pocżął Pán poſyłáć ná Judę Ráſyná / królá Syryjſkiego / y Fácejáƺá / ſyná Romelijáƺowego.
-Y záſnął Joátám z ojcámi ſwymi / y pogrzebiony jeſt z ojcámi ſwymi w mieśćie Dawidá / ojcá ſwego. A królował Acház / ſyn jego / miáſto niego.
+Y záráźił PAN Królá / á był trędowátym áż do śmierći ſwey / y mieƺkał w domu oſobnym : Przetoż Joátám Syn królewſki / rządźił domem / ſądząc lud źiemie.
+A inne ſpráwy Azáryaƺowe / y wƺyſtko co cżynił / ázaż tego nie zápiſano w Kronikách / o Królách Judſkich?
+Y záſnął Azáryaƺ z Ojcy ſwymi / á pochowano go z Ojcy jego / w mieśćie Dawidowym : A królował Joátám Syn jego miáſto niego.
+Roku trzydźieſtego y óſmego / Azáryaƺá Królá Judſkiego / królował Zácháryaƺ Syn Jeroboámów nád Izráelem w Sámáryjey / ƺeść mieśięcy.
+Y cżynił złe przed ocżymá Páńſkimi / jáko cżynili Ojcowie jego : nie odſtępując od grzechów Jeroboámá / Syná Nábátowego / który przywiódł do grzechu Izráelá.
+Y zprzyśiągł śię przećiw niemu Sellum / Syn Jábeſów / y ránił go przed ludem / y zábił go : á królował miáſto niego.
+A inne ſpráwy Zácháryaƺowe / oto ſą nápiſáne w Kronikách / o Królách Izráelſkich.
+Toć jeſt ono ſłowo Páńſkie / które powiedźiał do Jehu / mówiąc : Synowie twoji do cżwartego pokolenia / będą śiedźieli ná ſtolicy Izráelſkiey : y ták śię ſtáło.
+<i>Tedy</i> Sellum Syn Jábeſów / królował roku trzydźieſtego y dźiewiątego / roku Uzyaƺá Królá Judſkiego / á królował przez jeden mieśiąc w Sámáryjey.
+Bo przyćiągnąwƺy Mánáchem / Syn Gády z Terſy / á przyƺedƺy do Sámáryjey / poráźił Sellumá / ſyná Jábeſowego w Sámáryjey / á zábiwƺy go królował miáſto niego.
+A inne ſpráwy Sellumowe / y zprzyśiężenie jego / którym śię był zprzyśiągł / oto zápiſáne w Kronikách o Królách Izráelſkich.
+Tedy dobył Mánáchem <i>miáſtá Táfsy y pobił</i> wƺyſtkie którzy w nim byli / y wƺyſtkie gránice jego od Terſy : przeto że mu nie otworzyli / pomordował je / y wƺyſtkie brzemienne w nim porozćinał.
+Roku trzydźieſtego y dźiewiątego Azáryaƺá Królá Judſkiego / królował Mánáchem / Syn Gády / nád Izráelem dźieśięć lat w Sámáryjey.
+Y cżynił złe przed ocżymá Páńſkimi / nie odſtępując od grzechów Jeroboámá / Syná Nábátowego / który do grzechu przywodźił Izráelá po wƺyſtkie dni ſwoje.
+A gdy wyćiągnął Ful / Król Aſſyryjſki przećiw źiemi <i>Izraelſkiey</i> / dał Mánáchem Fulowi tyśiąc talentów śrebrá / áby mu był ná pomocy ku umocnieniu króleſtwá w rękách jego.
+Y ułożył Mánáchem podátek ná Izráelá / ná wƺyſtkie co nabogátƺe / áby dawáli Królowi Aſſyryjſkiemu / po pięćdźieśiąt ſyklów śrebrá / káżdy z oſobná : y wróćił śię Król Aſſyryjſki / á nie báwił śię tám w oney źiemi.
+A inne ſpráwy Mánáchemowe / y cokolwiek cżynił / nápiſáne ſą w Kronikách o Królách Izráelſkich.
+Y záſnął Mánáchem z Ojcy ſwymi / á królował Fácejaƺ Syn jego / miáſto niego.
+Roku pięćdźieśiątego Azáryaƺá Królá Judſkiego / królował Fácejaƺ Syn Mánáchemów nád Izráelem w Sámáryjey dwie lećie.
+Y cżynił złe przed ocżymá Páńſkimi / nie odſtępując od grzechu Jeroboámá Syná Nábátowego / który przywiódł do grzechu Izráelá.
+Tedy śię zbuntował przećiwko niemu Fácejaƺ / Syn Romeliaƺów / Hetman jego / y zábił go w Sámáryjey w páłacu domu królewſkiego / z Argobem / y z Ariaƺem / májąc z ſobą pięćdźieśiąt mężów Gáláádcżyków : á zábiwƺy go / królował miáſto niego.
+A inne ſpráwy Fácejaƺowe y wƺyſtko co cżynił / oto nápiſano w Kronikách o Królách Izráelſkich.
+Roku pięćdźieśiątego y wtórego Azáryaƺá Królá Judſkiego / królował Fácejaƺ Syn Romeliaƺów / nád Izráelem w Sámáryjey / dwádźieśćiá lat.
+Y cżynił złe przed ocżymá Páńſkimi : nie odſtępując od grzechów Jeroboámá Syná Nábátowego / który przywiódł do grzechu Izráelá.
+Zá dni Fácejaƺá / Królá Izráelſkiego / przyćiągnął Teglát Fáláſár Król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kedes y Azor / y Gáláád / y Gálileą / wƺyſtkę źiemię Neftáli : á przenióſł obywátele jey do Aſſyryjey.
+Tedy śię zbuntował Ozeaƺ Syn Ele / przećiw Fácejaƺowi / Synowi Romeliaƺowemu / á rániwƺy go / zábił go : y królował miáſto niego / roku dwudźieſtego / Joátámá Syná Uzyaƺowego.
+A inne ſpráwy Fácejaƺowe / y wƺyſtko co cżynił / oto zápiſano w Kronikách o Królách Izráelſkich.
+Roku wtórego Fácejaƺá Syná Romeliaƺowego Królá Izráelſkiego / królował Joátám Syn Uzyaƺá / Królá Judſkiego.
+Dwádźieśćiá y pięć lat miał gdy królowáć pocżął / á ƺeſnaśćie lat królował w Jeruzalem : Imię mátki jego Jeruſá / córká Sádokowá.
+Y cżynił co dobrego jeſt przed ocżymá Páńſkimi : według wƺyſtkiego / co cżynił Uzyaƺ Oćiec jego / poſtępował.
+Wƺákże wyżyny nie były znieśione : jeƺcże lud ofiárował y kádźił ná wyżynách : tenże zbudował bramę nawyżƺą domu Páńſkiego.
+A inne ſpráwy Joátámowe / y wƺyſtko co cżynił / zápiſano w Kronikách / o Królách Judſkich.
+Zá onych dni / pocżął PAN poſyłáć ná Judę Ráſyná Królá Syryjſkiego / y Fácejaƺá / Syná Romeliaƺowego.
+Y záſnął Joátám z Ojcy ſwymi / y pogrzebiony jeſt z Ojcy ſwymi w mieśćie Dawidá Ojcá ſwego. A królował Acház Syn jego miáſto niego.

--- a/1632/12-reg/15.txt
+++ b/1632/12-reg/15.txt
@@ -26,7 +26,7 @@ Tedy śię zbuntował przećiwko niemu Fácejaƺ / Syn Romeliaƺów / Hetman jeg
 A inne ſpráwy Fácejaƺowe y wƺyſtko co cżynił / oto nápiſano w Kronikách o Królách Izráelſkich.
 Roku pięćdźieśiątego y wtórego Azáryaƺá Królá Judſkiego / królował Fácejaƺ Syn Romeliaƺów / nád Izráelem w Sámáryjey / dwádźieśćiá lat.
 Y cżynił złe przed ocżymá Páńſkimi : nie odſtępując od grzechów Jeroboámá Syná Nábátowego / który przywiódł do grzechu Izráelá.
-Zá dni Fácejaƺá / Królá Izráelſkiego / przyćiągnął Teglát Fáláſár Król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kedes y Azor / y Gáláád / y Gálileą / wƺyſtkę źiemię Neftáli : á przenióſł obywátele jey do Aſſyryjey.
+Zá dni Fácejaƺá / Królá Izráelſkiego / przyćiągnął TeglátFáláſár Król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kedes y Azor / y Gáláád / y Gálileą / wƺyſtkę źiemię Neftáli : á przenióſł obywátele jey do Aſſyryjey.
 Tedy śię zbuntował Ozeaƺ Syn Ele / przećiw Fácejaƺowi / Synowi Romeliaƺowemu / á rániwƺy go / zábił go : y królował miáſto niego / roku dwudźieſtego / Joátámá Syná Uzyaƺowego.
 A inne ſpráwy Fácejaƺowe / y wƺyſtko co cżynił / oto zápiſano w Kronikách o Królách Izráelſkich.
 Roku wtórego Fácejaƺá Syná Romeliaƺowego Królá Izráelſkiego / królował Joátám Syn Uzyaƺá / Królá Judſkiego.

--- a/1632/12-reg/15.txt
+++ b/1632/12-reg/15.txt
@@ -26,7 +26,7 @@ Tedy śię zbuntował przećiwko niemu Fácejaƺ / Syn Romeliaƺów / Hetman jeg
 A inne ſpráwy Fácejaƺowe y wƺyſtko co cżynił / oto nápiſano w Kronikách o Królách Izráelſkich.
 Roku pięćdźieśiątego y wtórego Azáryaƺá Królá Judſkiego / królował Fácejaƺ Syn Romeliaƺów / nád Izráelem w Sámáryjey / dwádźieśćiá lat.
 Y cżynił złe przed ocżymá Páńſkimi : nie odſtępując od grzechów Jeroboámá Syná Nábátowego / który przywiódł do grzechu Izráelá.
-Zá dni Fácejaƺá / Królá Izráelſkiego / przyćiągnął TeglátFáláſár Król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kedes y Azor / y Gáláád / y Gálileą / wƺyſtkę źiemię Neftáli : á przenióſł obywátele jey do Aſſyryjey.
+Zá dni Fácejaƺá / Królá Izráelſkiego / przyćiągnął Teglát Fáláſár Król Aſſyryjſki / y wźiął Ajon y Abelbetmááchá / y Jánoe / y Kedes y Azor / y Gáláád / y Gálileą / wƺyſtkę źiemię Neftáli : á przenióſł obywátele jey do Aſſyryjey.
 Tedy śię zbuntował Ozeaƺ Syn Ele / przećiw Fácejaƺowi / Synowi Romeliaƺowemu / á rániwƺy go / zábił go : y królował miáſto niego / roku dwudźieſtego / Joátámá Syná Uzyaƺowego.
 A inne ſpráwy Fácejaƺowe / y wƺyſtko co cżynił / oto zápiſano w Kronikách o Królách Izráelſkich.
 Roku wtórego Fácejaƺá Syná Romeliaƺowego Królá Izráelſkiego / królował Joátám Syn Uzyaƺá / Królá Judſkiego.


### PR DESCRIPTION
w.16. "Tafsy" - niewyraźny skan 1632; 1660 i 1879 mają "Tafsy"; KJV:"Tiphsah"
w.19. skan 1632 ma "srebrá", 1660 "śrebrá" w reszcie tekstu zdaje się być pisownia przez "ś" (z wyjątkiem wyrazów zaczynających się z dużej litery - ze względów etetycznych brak "Ś" - choć dla jednolitej pisowni również powinny być zamienione na pisownię z "ś")