### PR TITLE
2 Król.16,6.

### DIFF
--- a/2023/12-reg/16.txt
+++ b/2023/12-reg/16.txt
@@ -1,0 +1,19 @@
+
+
+
+
+
+( Tegoż cżáſu Ráſyn Król Syryjſki / przywróćił záśię Elát do Syryjey / á wykorzenił Żydy z Elát ; ále Syryjcżycy przyƺedƺy do Elát / mieƺkáli tám áż do dniá tego. )
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
błąd w tłumaczeniu "Elot" - KJV i 1879 mają w tym wersecie 3 wystąpienia "Elat" (BG) / "Elath" (KJV); oryginał:  "אילת"
oraz "מאילות" - druga forma wynika z innej formy gramatycznej - połączenie przyimka מ־ („z, od”).