### PR TITLE
2 Król.17.

### DIFF
--- a/1632/12-reg/17.txt
+++ b/1632/12-reg/17.txt
@@ -1,41 +1,41 @@
-Roku dwunáſtego Acházá / królá Judzkiego / królował Ozeáƺ / ſyn Eli / w Sámáryi nád Izráelem dźiewięć lat.
-Y cżynił złe przed ocżymá Páńſkimi / wƺákże nie ták jáko inni królowie Izráelſcy / którzy byli przed nim.
-Przećiwko niemu wyćiągnął Sálmánáſár / król Aſſyryjſki ; y ſtał śię Ozeáƺ niewolnikiem jego / y dáwał mu dáń.
-A gdy obácżył król Aſſyryjſki / iż śię Ozeáƺ buntował przećiw niemu / á iż wypráwił poſły do Suá / królá Egipſkiego / y nie poſyłał dáni dorocżney królowi Aſſyryjſkiemu / obległ go król Aſſyryjſki / á związáwƺy podał go do więźieniá.
-Y ćiągnął król Aſſyryjſki przez wƺyſtkę źiemię / áż przyćiągnął do Sámáryi / pod którą leżał trzy látá.
-A roku dźiewiątego Ozeáƺá wźiął król Aſſyryjſki Sámáryję / y przenióſł Izráelá do Aſſyryi / á oſádźił je w Hálá y w Hábor nád rzeką Gozán y w miáſtách Medſkich.
-A to śię ſtáło przeto / że grzeƺyli ſynowie Izráelſcy przećiw Pánu / Bogu ſwemu / który je wywiódł z źiemi Egipſkiej / áby nie byli pod mocą Fáráoná / królá Egipſkiego ; á báli śię bogów cudzych /
-Chodząc w uſtáwách pogánów / które był Pán wyrzućił przed oblicżem ſynów Izráelſkich / y w uſtáwách królów Izráelſkich / które cżynili.
-Obłudnie ſynowie Izráelſcy poſtępowáli / cżyniąc co nie było rzecżą dobrą przed Pánem / Bogiem ſwym / y pobudowáli ſobie wyżyny po wƺyſtkich miáſtách ſwych / od wieży ſtráżników áż do miáſtá obronnego ;
-A náſtáwiáli ſobie ſłupów / y gájów ná káżdym págórku wynioſłym / y pod káżdym drzewem gáłęźiſtem /
-Páląc tám kádźidłá po wƺyſtkich górách / jáko narody / które wypędźił Pán przed oblicżem ich ; y cżynili rzecży co nájgorƺe / pobudzájąc Páná ku gniewu /
-A ſłużyli brzydkim báłwánom / o których im powiedźiał Pán / áby tego nie cżynili.
-Y oświádcżał śię Pán przećiwko Izráelowi / y przećiwko Judźie / przez wƺyſtkie proroki / y przez wƺyſtkie widzące / mówiąc : Náwróććie śię od dróg wáƺych złych / á ſtrzeżćie rozkázánia mego / y wyroków mojich według wƺyſtkiego zakonu / którym rozkázał ojcom wáƺym / á z którymem poſłał do was proroki / ſługi moje.
-Lecż nie byli poſłuƺni ; ále zátwárdźili kárk ſwój według kárku ojców ſwych / którzy nie wierzyli w Páná / Bogá ſwego.
-Y wzgárdźili wyroki jego / y przymierze jego / które ucżynił z ojcámi ich / y oświádcżeniá jego / któremi śię oświádcżał przećiwko nim / á chodźili zá próżnośćią / y ſtáli śię próżnymi / y náśládowáli pogánów / którzy byli około nich / o których im rozkázał Pán / áby nie cżynili jáko oni.
-Y opuśćiwƺy wƺyſtkie rozkázánia Páná / Bogá ſwego / pocżynili ſobie láne báłwány / miánowićie dwu ćielców ; pocżynili też gáje / á kłániáli śię wƺyſtkiemu wojſku niebieſkiemu / y ſłużyli Báálowi.
-Przewodźili też ſyny y córki ſwe przez ogień / y báwili śię wieƺcżbámi y wróżkámi / y záprzedáli śię / áby cżynili złe przed ocżymá Páńſkimi / pobudzájąc go do gniewu.
-Przetoż śię bárzo Pán rozgniewał ná Izráelá / á odrzućił je od oblicża ſwego / nic z nich nie zoſtáwując / oprócż ſámego pokolenia Judy.
-Aleć y Judá nie ſtrzegł przykázáń Páná / Bogá ſwego ; lecż chodźił w uſtáwách Izráelſkich / których nácżynili.
-Przetoż odrzućił Pán wƺyſtko naśienie Izráelſkie / y utrápił je / á podał je w rękę łupieżcom / áż je odrzućił od oblicża ſwego.
-Abowiem oderwał śię Izráel od domu Dawidowego / á poſtánowili królem Jeroboámá / ſyná Nábátowego ; ále Jeroboám odwiódł Izráelá od náśládowánia Páná / á przywiódł je do grzeƺeniá grzechem wielkim.
-Y chodźili ſynowie Izráelſcy we wƺyſtkich grzechách Jeroboámowych / które on cżynił / á nie odſtąpili od nich /
-Aż odrzućił Pán Izráelá od oblicża ſwego / jáko powiedźiał przez wƺyſtkie ſługi ſwe proroki ; á ták przenieśiony jeſt Izráel z źiemi ſwej do Aſſyryi / áż do dniá tego.
-Potem przyprowádźił król Aſſyryjſki lud z Bábilonu / y z Kutá / y z Awá / y z Emát / y z Sefárwáim / á oſádźił je w miáſtách Sámáryi miáſto ſynów Izráelſkich ; którzy pośiádƺy Sámáryję / mieƺkáli w miáſtách jey.
-A gdy tám oni mieƺkáć pocżęli á nie báli śię Páná / poſłał Pán ná nie lwy / którzy je zábijáli.
-Y powiedźiáno to królowi Aſſyryjſkiemu / mówiąc : Národowie / któreś przenióſł y oſádźił w miáſtách Sámáryi / nie wiedzą obycżáju Bogá oney źiemi ; przetoż poſłał ná nie lwy / á oto je zábijáją / dla tego / iż nie wiedzą obycżáju Bogá oney źiemi.
-Tedy rozkázał król Aſſyryjſki / mówiąc : Záwiedźćie tám jednego z kápłanów / któreśćie z támtąd przywiedli / áby poƺedƺy mieƺkał tám / y náucżał ich obycżáju Bogá oney źiemi.
-Przyƺedł tedy jeden z kápłanów / których było wźięto z Sámáryi / y mieƺkał w Betel / á náucżał ich / jáko śię mieli báć Páná.
-Wƺákże nácżynili ſobie káżdy naród bogów ſwych / y poſtáwili je w domu wyżyn / które byli pobudowáli Sámáryjcżycy / káżdy naród w miáſtách ſwych / w których mieƺkáli /
-Abowiem mężowie Bábilońſcy ucżynili Sukkotbenot / á mężowie Kutſcy ucżynili Nergiel / á mężowie Emátſcy ucżynili Aſymá.
-A Hewejcżycy ucżynili Nebáház / y Tárták ; á Sefárwáicżycy pálili ſyny ſwe w ogniu Adrámelechowi / y Anámelechowi / bogom Sefárwáimſkim.
-A ták báli śię Páná / nácżyniwƺy ſobie z pośrzodku śiebie kápłanów ná wyżynách / którzy im uſługiwáli w domách wyżyn.
-A choć śię Páná báli / wƺákże przećię bogom ſwoim ſłużyli według zwycżáju onych narodów / ſkąd byli przenieśieni.
-Ci áż do dniá tego ſpráwują śię według zwycżájów ſtárych / nie boją śię Páná / áni cżynią według wyroków jego / y według uſtáw jego / y według zakonu / y według rozkázánia / które przykázał Pán ſynom Jákóbowym / którego przezwał Izráelem.
-Ucżynił też był Pán z nimi przymierze / y rozkázał im / mówiąc : Nie bójćie śię bogów cudzych / y nie kłániájćie śię im / áni im ſłużćie / áni im ofiárujćie ;
-Ale Páná / który was wywiódł z źiemi Egipſkiej mocą wielką y rámieniem wyćiągnionem / tego śię bójćie / y jemu śię kłániájćie / y jemu ofiárujćie ;
-Tákże uſtáw / y ſądów / y zakonu / y przykázáń / które wam nápiſał / ſtrzeżćie / cżyniąc je po wƺyſtkie dni / á nie bójćie śię bogów cudzych.
-Więc przymierza / którem cżynił z wámi / nie zápominájćie / áni śię bójćie bogów cudzych.
-Ale Páná / Bogá wáƺego / śię bójćie / á on was wybáwi z ręki wƺyſtkich nieprzyjáćiół wáƺych ;
-Lecż nie uſłucháli / ále owƺem według obycżáju ſwego dáwnego cżynili.
-A ták národowie oni báli śię Páná / wƺákże przećię rytym báłwánom ſwoim ſłużyli ; á ſynowie ich / y ſynowie ſynów ich / według wƺyſtkiego / co cżynili ojcowie ich / ták y oni cżynią / áż po dźiś dźień.
+Roku dwunaſtego Acházá Królá Judſkiego / królował Ozeaƺ Syn Ele w Sámáryjey / nád Izráelem dźiewięć lat.
+Y cżynił złe przed ocżymá Páńſkimi / wƺákże nie ták jáko <i>inni</i> Królowie Izráelſcy / którzy byli przed nim.
+Przećiwko niemu wyćiągnął Sálmánáſár / Król Aſſyryjſki : y ſtał śię Ozeaƺ niewolnikiem jego / y dawał mu dań.
+A gdy obacżył Król Aſſyryjſki / iż śię Ozeaƺ buntował <i>przećiw niemu,</i> á iż wypráwił poſły do Suá Królá Egipſkiego / y nie poſyłał dáni dorocżney Królowi Aſſyryjſkiemu / obległ go Król Aſſyryjſki : á związawƺy / podał go do więźienia.
+Y ćiągnął Król Aſſyryjſki przez wƺyſtkę źiemię / áż przyćiągnął do Sámáryjey / pod którą leżał trzy látá.
+A roku dźiewiątego Ozeaƺá / wźiął Król Aſſyryjſki Sámáryją / y przenióſł Izráelá do Aſſyryjey / á oſádźił je w Hálá y w Hábor nád rzeką Gozán / y w miáſtách Medſkich.
+A to śię ſtáło <i>przeto,</i> że grzeƺyli Synowie Izráelſcy przećiw PANU Bogu ſwemu / ( który je wywiódł z źiemie Egipſkiey / áby nie byli pod mocą Fáráoná Królá Egipſkiego ) á bali śię Bogów cudzych :
+Chodząc w uſtáwách pogánów które był PAN wyrzućił przed oblicżem Synów Izráelſkich / y <i>w uſtáwách</i> Królów Izráelſkich które cżynili.
+Obłudnie Synowie Izráelſcy poſtępowáli / <i>cżyniąc</i> co nie było rzecżą dobrą przed PANEm Bogiem ſwym : y pobudowáli ſobie wyżyny po wƺyſtkich miáſtách ſwych / od wieże ſtrażników / áż do miáſtá obronnego.
+A náſtawiáli ſobie ſłupów / y gájów / ná káżdym págórku wynioſłym / y pod káżdym drzewem gáłęźiſtym.
+Paląc tám kádźidłá po wƺyſtkich górách / jáko narodowie / które wypędźił Pan przed oblicżem ich : y cżynili rzecży co nagorƺe / pobudzájąc PANA ku gniewu.
+A ſłużyli brzydkim báłwanom / o których im powiedźiał PAN ; áby tego nie cżynili.
+Y oświadcżał śię PAN przećiwko Izráelowi / y przećiw Judźie / przez wƺyſtkie proroki / y przez wƺyſtkie Widzące / mówiąc : Náwróććie śię od dróg wáƺych złych / á ſtrzeżćie rozkazánia mego / <i>y</i> wyroków mojich / według wƺyſtkiego zakonu / którym rozkazał Ojcom wáƺym / á z którymem poſyłał do was proroki ſługi moje.
+Lecż nie byli poſłuƺni / ále zátwárdźili kárk ſwój / według kárku Ojców ſwych / którzy nie wierzyli w PANA Bogá ſwego.
+Y wzgárdźili wyroki jego / y przymierze jego które ucżynił z Ojcy ich / y oświadcżánia jego / którymi śię oświadcżał przećiwko nim ; á chodźili zá próznośćią / y ſtali śię próznymi : y náśládowáli pogánów / którzy byli około nich / o których im rozkazał PAN / áby nie cżynili jáko oni.
+Y opuśćiwƺy wƺyſtkie rozkazánia PAná Bogá ſwego / pocżynili ſobie lane báłwany / <i>miánowićie</i> dwu ćielców : pocżynili też gáje / á kłaniáli śię wƺyſtkiemu wojſku niebieſkiemu / y ſłużyli Báálowi.
+Przewodźili też Syny y córki ſwe przez ogień / y báwili śię wieƺcżbámi y wróƺkámi / y záprzedáli śię / áby cżynili złe przed ocżymá Páńſkimi / pobudzájąc go do gniewu.
+Przetoż śię bárzo PAN rozgniewał ná Izráelá / á odrzućił je od oblicża ſwego : nic <i>z nich</i> nie zoſtáwując / oprócż ſámego pokolenia Judá.
+Aleć y Judá nie ſtrzegł przykazań PANA Bogá ſwego ; lecż chodźił w uſtáwách Izráelſkich / których nácżynili.
+Przetoż odrzućił PAN wƺyſtko naśienie Izráelſkie y utrapił je / á podał je w rękę łupieżcom / áż je odrzućił od oblicża ſwego.
+Abowiem oderwał śię Izráel od domu Dawidowego / á poſtánowili Królem Jeroboámá Syná Nábotowego : ále Jeroboám odwiódł Izráelá / od náśládowánia PANA / á przywiódł je do grzeƺenia grzechem wielkim.
+Y chodźili Synowie Izráelſcy we wƺyſtkich grzechách Jeroboámowych / które on cżynił / á nie odſtąpili od nich :
+Aż odrzućił PAN Izráelá od oblicża ſwego / jáko powiedźiał przez wƺyſtkie ſługi ſwe proroki / á ták przenieśiony jeſt Izráel z źiemie ſwey do Aſſyryjey / áż do dniá tego.
+Potym przyprowádźił Król Aſſyryjſki <i>lud</i> z Bábilonu / y z Kutá / y z Awá / y z Emát / y z Sefárwáim / á oſádźił je w mieśćiech Sámáryjey / miáſto Synów Izráelſkich : którzy pośiadƺy Sámáryją mieƺkáli w mieśćiech jey.
+A gdy tám oni mieƺkáć pocżęli / á nie bali śię PAná / poſłał PAN ná nie Lwy / którzy je zábijáli.
+Y powiedźiano to Królowi Aſſyryjſkiemu / mówiąc : Narodowie któreś przenióſł / y oſádźił w mieśćiech Sámáryjey / nie wiedzą obycżáju Bogá oney źiemie / przetoż poſłał ná nie lwy / á oto je zábijáją / dla tego / iż nie wiedzą obycżáju Bogá oney źiemie.
+Tedy rozkazał Król Aſſyryjſki / mówiąc : Záwiedźćie tám jednego z Kápłanów / któreśćie z támtąd przywiedli / áby poƺedƺy mieƺkał tám y náucżał jch obycżáju Bogá oney źiemie.
+Przyƺedł tedy jeden z Kápłanów których było wźięto z Sámáryjey / y mieƺkał w Bethel / á náucżał jch jáko śię mieli bać PANA.
+Wƺákże nácżynili ſobie káżdy naród Bogów ſwych / y poſtáwili je w domu wyżyn / które byli pobudowáli Sámáryjcżycy / káżdy naród w mieśćiech ſwych / w których mieƺkáli.
+Abowiem mężowie Bábilońſcy / ucżynili Sukkotbenot : á mężowie Kutſcy / ucżynili Nergel / á mężowie Emátſcy ucżynili Aſymá :
+A Hewejcżycy ucżynili Nebáház / y Tárták : á Sefárwájcżycy palili Syny ſwe w ogniu Adrámelechowi / y Anámelechowi Bogom Sefárwájimſkim.
+A ták bali śię PANA / nácżyniwƺy ſobie z pośrzodku śiebie kápłanów ná wyżynách którzy im uſługowáli w domiech wyżyn.
+A choć śię PAná bali / wƺákże <i>przećię</i> Bogō ſwojim ſłużyli / według zwycżáju onych narodów / z kąd byli przenieśieni.
+Ci áż do dniá tego ſpráwują śię według zwycżájów ſtárych / nie boją śię PANA / áni cżynią według wyroków jego / y według uſtaw jego / y według Zakonu / y według rozkazánia które przykazał PAN Synom Jákóbowym / którego przezwał Izráelem.
+Ucżynił też był PAN z nimi przymierze / y rozkazał im / mówiąc : Nie bójćie śię Bogów cudzych / y nie kłaniajćie śię im / áni im ſłużćie / áni im ofiárujćie :
+Ale PANA / który was wywiódł z źiemie Egipſkiey mocą wielką / y rámieniem wyćiągnionym / tego śię bójćie / y jemu śię kłaniajćie / y jemu ofiárujćie.
+Tákże uſtaw / y ſądów / y Zakonu / y przykazań / które wam nápiſał / ſtrzeżćie / cżyniąc je po wƺyſtkie dni / á nie bójćie śię Bogów cudzych.
+Więc przymierza / którem ucżynił z wámi / nie zápominajćie / áni śię bójćie Bogów cudzych.
+Ale PAná Bogá wáƺego śię bójćie / á on was wybáwi z ręki wƺyſtkich nieprzyjaćiół wáƺych.
+Lecż nie uſłucháli / ále owƺem według obycżáju ſwego dawnego cżynili.
+A ták narodowie oni bali śię PANA / wƺákże przećię rytym báłwanom ſwojim ſłużyli / á Synowie jch / y Synowie Synów jch / według wƺyſtkiego co cżynili Ojcowie jch / ták y oni cżynią / áż po dźiś dźień.


### PR DESCRIPTION
w.15. 1632 ma "przymierże"; 1660 "przymierze" zostawiłem jak w 1660; również zdaje się zasadą jest pisownia przez "rz"
w.21. "Nabotowego"? 1879 "Nabatowego", KJV "Nebat"
w.25-26. "lwy"/"Lwy" 1879 i KJV mają oba wyrazy pisane z małej litery
w.27;41. 1660 ma "ich"
w.33 "ō" -> "om"; por. 1660. Choć np. Ps.16,4. "imiō" -> "imion" por. 1660. - zostawiłem "ō".