### PR TITLE
2 Król.18.

### DIFF
--- a/1632/12-reg/18.txt
+++ b/1632/12-reg/18.txt
@@ -1,37 +1,37 @@
-Roku trzećiego Ozeáƺá / ſyná Eli / królá Izráelſkiego / królował Ezechyjáƺ / ſyn Acházá / królá Judzkiego.
-Dwádźieśćiá y pięć lat mu było / gdy pocżął królowáć ; á dwádźieśćiá y dźiewięć lat królował w Jeruzálemie. Imię mátki jego było Abi / córká Zácháryjáƺowá.
-Y cżynił co było dobrego przed ocżymá Páńſkimi / według wƺyſtkiego / jáko cżynił Dawid / oćiec jego.
-On znióſł wyżyny / y ſkruƺył báłwány / y powyćinał gáje / á pokruƺył wężá miedźiánego / którego był ucżynił Mojzeƺ ; bo áż do onych dni Izráelcżycy kádźili mu / y názwał go Nehuſtán.
-W Pánu Bogu Izráelſkim ufał ; á po nim nie był żáden podobny jemu miedzy wƺyſtkimi królámi Judzkimi / y którzy byli przed nim.
-Bo śię trzymał Páná / nie odſtępując od niego / á ſtrzegąc przykázánia jego / które był przykázał Pán Mojżeƺowi.
-A Pán był z nim ; y we wƺyſtkim / do cżego śię obróćił / ƺcżęśćiło mu śię. Wybił śię też z mocy królowi Aſſyryjſkiemu / y nie ſłużył mu.
-Tenże poráźił Filiſtyny áż do Gázy y gránic jego / od wieży ſtráżników áż do miáſtá obronnego.
-Roku cżwártego królá Ezechyjáƺá / ( który był rok śiódmy Ozeáƺá / ſyná Eli / królá Izráelſkiego ) wyćiągnął Sálmánáſár / król Aſſyryjſki / przećiwko Sámáryi / y obległ ją.
-A wźiął ją przy dokońcżeniu trzećiego roku ; roku ƺóſtego Ezechyjáƺá / ( który był rok dźiewiąty Ozeáƺá / królá Izráelſkiego ) wźiętá jeſt Sámáryjá.
-Tedy przenióſł król Aſſyryjſki Izráelá do Aſſyryi / y oſádźił nimi Hálách y Hábor u rzeki Gázán / y miáſtá Medſkie.
-Przeto / iż nie poſłucháli głoſu Páná Bogá ſwego / ále przeſtępowáli przymierze jego / y tego wƺyſtkiego / co rozkázał Mojzeƺ / ſługá Páńſki / nie ſłucháli y nie cżynili.
-Potem cżternáſtego roku królá Ezechyjáƺá ruƺył śię Sennácheryb / król Aſſyryjſki / przećiw wƺyſtkim miáſtom Judzkim obronnym / y wźiął je.
-A ták poſłał Ezechyjáƺ / król Judzki / do królá Aſſyryjſkiego / do Láchys / mówiąc : Zgrzeƺyłem ; odćiągnij odemnie / cokolwiek ná mię włożyƺ / ponioſę. Tedy włożył król Aſſyryjſki ná Ezechyjáƺá / królá Judzkiego / dáń trzy ſtá tálentów ſrebrá / y trzydźieśći tálentów złotá.
-Y dał Ezechyjáƺ wƺyſtko ſrebro / które śię ználázło w domu Páńſkim y w ſkárbách domu królewſkiego.
-Onegoż cżáſu obłupił Ezechyjáƺ drzwi domu Páńſkiego / y ſłupy / które ſámże Ezechyjáƺ / król Judzki / był obył / á dał je królowi Aſſyryjſkiemu.
-Wƺákże poſłał król Aſſyryjſki Tártáná / y Rábſáryſá / y Rábſáceſá z Láchys do królá Ezechyjáƺá z wielkiem wojſkiem do Jeruzálemu. Którzy wyćiągnąwƺy przyjecháli ku Jeruzálemowi / á przyćiągnąwƺy przyƺli y położyli śię u rur ſádzáwki wyżƺej / która jeſt podle drogi brukowáney ná polu blechárzowem.
-A gdy wołáli ná królá / wyƺedł do nich Elijákim / ſyn Helkijáƺowy / przełożony nád domem / y Sobná piſárz / y Joách ſyn Aſáfowy / kánclerz.
-Y rzekł do nich Rábſáces : Proƺę powiedzćie Ezechyjáƺowi : Ták mówi król wielki / król Aſſyryjſki : Co to zá ufność / ná którey śię wſpieráƺ?
-Mówiłeś : ( áleć to ſłowá dáremne ) Rády y mocy mam doſyć do wojny. A teraz w kimże ufáƺ / żeś mi śię ſprzećiwił?
-Oto teraz ſpolegáƺ ná Egipćie / jáko ná láſce trzćinney / y to náłámáney / którą jeſliby śię kto podpierał / tedy wnijdźie w rękę jego y przekole ją. Tákić jeſt Fáráo / król Egipſki / wƺyſtkim / co w nim ufáją.
-A jeſli mi rzecżećie : W Pánu Bogu náƺym ufność mamy : ázaż nie ten jeſt / którego znióſł Ezechyjáƺ wyżyny y ołtárze? y rozkázał Judźie y Jeruzálemowi / mówiąc : Przed tym ołtárzem kłániáć śię będźiećie w Jeruzálemie.
-Przetoż teraz záręcż śię królowi Aſſyryjſkiemu / pánu memu / á dam ći dwá tyśiące koni ; będźieƺli mógł mieć jezdnych ták wiele do nich?
-Y jákoż śię ty możeƺ oprzeć hetmánowi jednemu nájmniejƺemu z ſług páná mego? choć pokłádáƺ nádźieję w Egipćie dla wozów y jezdnych.
-Nádto / cży bez woli Páńſkiej przyćiągnąłem przećiw temu miejſcu / ábym je zburzył? Pán mówił do mnie : Idź do tey źiemi / á ſpuſtoƺ ją.
-Tedy rzekł Elijákim / ſyn Helkijáƺowy / y Sobná / y Joách do Rábſáceſá : Proƺę mów do ſług twojich po ſyryjſku / boć rozumiemy ; á nie mów z námi po żydowſku / gdźie ſłyƺy lud / który jeſt ná murze.
-Którym odpowiedźiał Rábſáces : Azaż mię do páná twego / álbo do ćiebie przyſłał Pán mój / ábym te ſłowá mówił? Azaż nie do tych mężów / którzy śiedzą ná murze / áby jedli łájná ſwoje / y pili mocż ſwój z wámi.
-A ták ſtánąwƺy Rábſáces wołał głoſem wielkim po żydowſku / á mówiąc rzekł : Słuchájćie ſłów królá wielkiego / królá Aſſyryjſkiego.
-Ták mówi król : Niech was nie zwodźi Ezechyjáƺ ; bo was nie będźie mógł wyrwáć z ręki mojey.
-A niech wam nie rozkázuje ufáć Ezechyjáƺ w Pánu / mówiąc : Pewnie nas wyrwie Pán / á nie będźie podáne to miáſto w ręce królá Aſſyryjſkiego.
-Nie ſłuchájćie Ezechyjáƺá. Abowiem ták mówi król Aſſyryjſki : Ucżyńćie ze mną przymierze / á wynijdźćie do mnie / á jedzćie káżdy z winnicy ſwojey y káżdy z figi ſwojey / y pijćie káżdy wodę z ſtudnicy ſwojey /
-Aż przydę / á pobiorę was do źiemi podobney źiemi wáƺej / do źiemi żyzney / y obfitującey winem / do źiemi chlebá y winnic / do źiemi drzew oliwnych / y oliwy / y miodu ; y będźiećie żyli / á nie pomrzećie. Nie ſłuchájćież Ezechyjáƺá ; bo was zwodźi / mówiąc : Pán was wybáwi.
-Izáż mogli bogowie narodów wybáwić / káżdy źiemię ſwoję / z ręki królá Aſſyryjſkiego?
-Gdźież jeſt bóg Emát y Arfád? gdźież jeſt bóg Sefárwáim / Aná y Awá? izali wyrwáli Sámáryję z rąk mojich?
-Któryż jeſt miedzy wƺyſtkimi bogi tych źiem / któryby wyrwał źiemię ſwoję z ręki mojey? A miáłby Pán wyrwáć Jeruzálem z ręki mojey?
-Ale milcżał lud / y nie odpowiedźieli mu y ſłowá ; bo tákie było rozkázánie królewſkie / mówiąc : Nie odpowiádájćie mu.
-Przyƺedł tedy Elijákim / ſyn Helkijáƺowy / przełożony domu / y Sobná piſárz / y Joách / ſyn Aſáfowy / kánclerz / do Ezechyjáƺá / rozdárƺy ƺáty ſwe / y oznájmili mu ſłowá Rábſáceſowe.
+Roku trzećiego Ozeaƺá Syná Ele / Królá Izráelſkiego / królował Ezechiaƺ / Syn Acházá Królá Judſkiego.
+Dwádźieśćiá y pięć lat mu było gdy pocżął królowáć : á dwádźieśćiá y dźiewięć lat królował w Jeruzalem : imię mátki jego <i>było</i> Abi / córká Zácháryaƺowá.
+Y cżynił co było dobrego przed ocżymá Páńſkimi / według wƺyſtkiego / jáko cżynił Dawid Oćiec jego.
+On znióſł wyżyny / y ſkruƺył báłwany / y powyćinał gáje / á pokruſzył wężá miedźiánego / którego był ucżynił Mojzeƺ : bo áż do onych dni Izráelcżycy kádźili mu : y názwał go Nehuſtán.
+W PANU Bogu Izráelſkim ufał : á po nim nie był żaden podobny jemu miedzy wƺyſtkimi Królmi Judſkimi / y którzy byli przed nim.
+Bo śię trzymał PANA / nie odſtępując od niego / á ſtrzegąc przykazánia jego / które był przykazał PAN Mojzeƺowi.
+A PAN był z nim : y we wƺyſtkim do cżego śię obróćił ƺcżeśćiło mu śię : Wybił śię też z mocy Królowi Aſſyryjſkiemu / y nie ſłużył mu.
+Tenże poráźił Filiſtyny áż do Gázy / y gránic jego / od wieże ſtrażników / áż do miáſtá obronnego.
+Roku cżwartego Królá Ezechiaƺá / ( który był rok śiódmy Ozeaƺá Syná Ele Królá Izráelſkiego ) wyćiągnął Sálmánáſár Król Aſſyryjſki / przećiwko Sámáryjey / y obległ ją.
+A wźiął ją przy dokońcżeniu trzećiego roku / roku ƺóſtego Ezechiaƺá / ( który był rok dźiewiąty Ozeaƺá Królá Izráelſkiego ) wźiętá jeſt Sámáryja.
+Tedy przenióſł Król Aſſyryjſki Izráelá do Aſſyryjey / y oſádźił nimi Hálách y Hábor / u rzeki Gozán / y miáſtá Medſkie.
+Przeto iż nie poſłucháli głoſu PANA Bogá ſwego / ále przeſtępowáli przymierze jego / <i>y</i> tego wƺyſtkiego co rozkazał Mojzeƺ ſługá Páńſki / nie ſłucháli / y nie cżynili.
+Potym cżternaſtego roku / Królá Ezechiaƺá / ruƺył śię Sennácheryb Król Aſſyryjſki / przećiw wƺyſtkim miáſtam Judſkim obronnym / y wźiął je.
+A ták poſłał Ezechiaƺ Król Judſki do Królá Aſſyryjſkiego / do Láchis / mówiąc : Zgrzeƺyłem ; odćiągni odemnie / cokolwiek ná mię włożyƺ ponioſę. Tedy włożył Król Aſſyryjſki / ná Ezechiaƺá Królá Judſkiego <i>dań</i> trzy ſtá talentów śrebrá / y trzydźieśći talentów złotá.
+Y dał Ezechiaƺ wƺyſtko śrebro które śię ználázło w domu Páńſkim / y w ſkárbiech domu królewſkiego.
+Onegoż cżáſu obłupił Ezechiaƺ drzwi domu Páńſkiego / y ſłupy / które <i>ſamże</i> Ezechiaƺ Król Judſki był obił / á dał je Królowi Aſſyryjſkiemu.
+Wƺákże poſłał Król Aſſyryjſki Tártáná / y Rábſáriſá / y Rábſáceſá z Láchis do Królá Ezechiaƺá / z wielkim wojſkiem do Jeruzalem : którzy wyćiągnąwƺy / przyjácháli ku Jeruzalem / á przyćiągnąwƺy / przyƺli y położyli śię u rur ſadzawki wyżƺey / która jeſt podle drogi brukowáney / ná polu blechárzowym.
+A gdy wołáli ná Królá / wyƺedł do nich Eliákim / Syn Helkiaƺów / Przełożony nád domem / y Sobná Piſarz / y Joách Syn Aſáfów Kánclerz.
+Y rzekł do nich Rábſáces : Proƺę powiedzćie Ezechiaƺowi : Ták mówi Król wielki / Król Aſſyryjſki : Co to zá ufność / ná którey śię wſpieraƺ?
+Mówiłeś ( áleć to ſłowá dáremne ) rády y mocy mam doſyć do wojny : A teraz w kimże ufaƺ / żeś mi śię ſprzećiwił?
+Oto teraz ſpolegaƺ ná Egipćie <i>jáko</i> ná laſce trzćinney / y to náłamáney : którą jeſliby śię kto podpierał / tedy wnidźie w rękę jego / y przekole ją : Tákić jeſt Fáráo Król Egipſki wƺyſtkim co w nim ufáją.
+A jeſli mi rzecżećie : W PANU Bogu náƺym ufność mamy : ázaż nie ten jeſt / którego znióſł Ezechiaƺ wyżyny y Ołtarze? y rozkazał Judzie y Jeruzalemowi <i>mówiąc</i> : Przed tym Ołtarzem kłaniáć śię będźiećie w Jeruzalem.
+Przetoż teraz / záręcż śię Królowi Aſſyryjſkiemu Pánu memu / á damći dwá tyśiącá koni / będźieƺli mógł mieć jezdnych ták wiele do nich.
+Y jákoż śię ty możeƺ oprzeć Hetmánowi jednemu namniejƺemu z ſług Páná mego / choć pokładaƺ nádźieję w Egipćie / dla wozów y jezdnych?
+Nád to ; cży bez <i>woli</i> Páńſkiey przyćiągnąłem przećiw temu miejſcu / ábym je zburzył? PAN mówił do mnie : Jedź do tey źiemie / á zpuſtoƺ ją.
+Tedy rzekł Eliákim Syn Helkiaƺów / y Sobná / y Joách / do Rábſáceſá ; Proƺę mów do ſług twojich po Syryjſku / boć rozumiemy / á nie mów z námi po żydowſku / gdźie ſłyƺy lud który jeſt ná murze.
+Którym odpowiedźiał Rábſáces : Azaż mię do Páná twego / álbo do ćiebie przyſłał Pan mój ábym te ſłowá mówił? Azaż nie do tych mężów / którzy śiedzą ná murze / áby jedli łájná ſwoje / y pili mocż ſwój z wámi?
+A ták ſtánąwƺy Rábſáces / wołał głoſem wielkim po żydowſku : á mówiąc rzekł : Słuchajćie ſłów Królá wielkiego / Królá Aſſyryjſkiego.
+Ták mówi Król : Niech was nie zwodźi Ezechiaƺ / bo was nie będźie mógł wyrwáć z ręki mojey.
+A niech wam nie rozkázuje ufáć Ezechiaƺ w PANU / mówiąc : Pewnie nas wyrwie PAN / á nie będźie podáne to miáſto w ręce Królá Aſſyryjſkiego.
+Nie ſłuchajćie Ezechiaƺá : Abowiem ták mówi Król Aſſyryjſki : Ucżyńćie ze mną przymierze / á wynidźćie do mnie : á jedzćie káżdy z winnice ſwojey y káżdy z figi ſwojey / y pjićie káżdy wodę z ſtudnice ſwojey :
+Aż przydę / á pobiorę was do źiemie podobney źiemi wáƺey / do źiemie żyzny / y <i>obfitującey</i> winem / do źiemie chlebá y winnic / do źiemie drzew Oliwnych / y Oliwy / y miodu : y będźiećie żyli / á nie pomrzećie. Nie ſłuchajćież Ezechiaƺá : bo was zwodźi / mówiąc ; PAn nas wybáwi.
+Izaż mogli Bogowie narodów wybáwić káżdy źiemię ſwoję / z ręki Królá Aſſyryjſkiego?
+Gdźież jeſt Bóg Emát / y Arfád? gdźież jeſt Bóg Sefárwáim / Aná y Awá / yzali wyrwáli Sámáryją z rąk mojich?
+Któryż jeſt miedzy wƺyſtkimi Bogi tych źiem / któryby wyrwał źiemię ſwoję z ręki mojey? A miałby PAN wyrwáć Jeruzalem z ręki mojey?
+Ale milcżał lud / y nie odpowiedźieli mu y ſłowá ; Bo tákie było rozkazánie królewſkie / mówiąc : Nie odpowiádajćie mu.
+Przyƺedł tedy Eliákim / Syn Helkiaƺów / przełożony domu / y Sobná piſarz / y Joách Syn Aſáfów Kánclerz / do Ezechiaƺá / rozdárƺy ƺáty <i>ſwe</i> / y oznájmili mu ſłowá Rábſáceſowe.


### PR DESCRIPTION
w.4. 1660 ma "pokruƺył"
w.22. "Judzie" -> "Judźie" ?
w.34. "yzali", 1660 ma "izali" regułą też jest występowanie drugiej formy 