### PR TITLE
2 Król.19.

### DIFF
--- a/1632/12-reg/19.txt
+++ b/1632/12-reg/19.txt
@@ -1,37 +1,37 @@
-A gdy to uſłyƺał król Ezechyjáƺ / rozdárł ƺáty ſwoje / á oblekł śię w wór / y wƺedł do domu Páńſkiego ;
-Y poſłał Elijákimá / ſpráwcę domu ſwego / y Sobnę piſárzá / y ſtárƺe z kápłanów / oblecżone w wory / do Izájáƺá proroká / ſyná Amoſowego.
-Którzy rzekli do niego : Ták mówi Ezechyjáƺ : Dźień utrapienia / y łájánia / y bluźnierſtwá jeſt ten dźień ; ábowiem ſynowie przyƺli áż do porodzeniá / á śiły niemáƺ ku rodzeniu.
-Oby uſłyƺał Pán / Bóg twój / wƺyſtkie ſłowá Rábſáceſowe / którego przyſłał król Aſſyryjſki / pán jego / urągáć Bogu żywemu! áby śię pomśćił onych ſłów / które ſłyƺał Pán / Bóg twój. Przetoż ucżyń modlitwę zá te oſtátki / które śię znájdują.
-Przyƺli tedy ſłudzy królá Ezechyjáƺá do Izájáƺá.
-Którym odpowiedźiał Izájáƺ : Ták powiedzćie pánu wáƺemu : To mówi Pán : Nie bój śię tych ſłów / któreś ſłyƺał / któremi mię lżyli ſłudzy królá Aſſyryjſkiego.
-Oto Ja puƺcżę nań duchá / y uſłyƺy wieść / á wróći śię do źiemi ſwojey / y położę go miecżem w źiemi jego.
-Ale wróćiwƺy śię Rábſáces ználázł królá Aſſyryjſkiego dobywájącego Lebny ; ábowiem uſłyƺał / iż odćiągnął był od Láchys.
-A uſłyƺáwƺy o Tyráku / królu Etyjopſkim / że mówiono : Oto wyćiągnął ná wojnę przećiwko tobie / znowu poſłał poſły do Ezechyjáƺá / mówiąc :
-To powiedzćie Ezechyjáƺowi / królowi Judzkiemu / mówiąc : Niech ćię nie zwodźi Bóg twój / któremu ty ufáƺ / á mówiƺ : Nie będźie podáne Jeruzálem w ręce królá Aſſyryjſkiego.
-Otoś ſłyƺał / co pocżynili królowie Aſſyryjſcy wƺyſtkim źiemiom / burząc je ; á ty byś miał być wybáwiony?
-Izali wybáwili bogowie narodów te / które wygubili ojcowie moi / Gozán / y Hárán / y Reſef / y ſyny Eden / którzy byli w Teláſſár?
-Gdźież jeſt król Emát / y król Arfád / y król miáſtá Sefárwáim / Aná y Awá?
-Przetoż wźiąwƺy Ezechyjáƺ liſt z ręki poſłów / przecżytał go / y wƺedƺy do domu Páńſkiego rozćiągnął go Ezechyjáƺ przed Pánem.
-Y modlił śię Ezechyjáƺ przed Pánem / mówiąc : Pánie / Boże Izráelſki / śiedzący ná Cherubinách! ty / tyś ſám jeſt Bóg wƺyſtkich króleſtw źiemi / tyś ſtworzył niebo y źiemię.
-Nákłońże / Pánie! uchá twojego / á uſłyƺ ; otwórz / Pánie! ocży twoje / á obácż ; uſłyƺ ſłowá Sennácherybá / który przyſłał háńbić ćiebie / Bogá żywego.
-Práwdáć jeſt / Pánie! że ſpuſtoƺyli królowie Aſſyryjſcy narody one / y źiemię ich.
-Y powrzucáli bogi ich w ogień ; ábowiem nie byli bogowie / ále robotá rąk ludzkich / drewno / y kámień ; przetoż je wygubili.
-A teraz / o Pánie Boże náƺ! wybáw nas proƺę z ręki jego / áby poznáły wƺyſtkie króleſtwá źiemi / żeś ty / Pánie! ſám Bogiem.
-Tedy poſłał Izájáƺ / ſyn Amoſowy / do Ezechyjáƺá / mówiąc : Ták mówi Pán / Bóg Izráelſki : O coś mię prośił z ſtrony Sennácherybá / królá Aſſyryjſkiego / wyſłucháłem ćię.
-A teć ſą ſłowá / które mówił Pán o nim : Pánná / córká Syońſká / wzgárdźiłá ćię / śmiáłá śię z ćiebie / kiwáłá głową zá tobą córká Jeruzálemſká.
-Kogożeś háńbił / y kogoś bluźnił? przećiwko komużeś podnióſł głos / á wynioſłeś ku górze ocży ſwoje? przećiw Świętemu Izráelſkiemu.
-Przez poſły twoje háńbiłeś Páná mego / y rzekłeś : W mnóſtwie wozów mojich wſtąpiłem ná wyſokie góry / y ná ſtrony Libáńſkie / y podrąbię wyſokie cedry jego / y wyborne jodły jego / y przydę áż do oſtátnich przybytków jego / do láſów / y wybornych ról jego.
-Jam wykopał źródłá / y piłem wody cudze / á wyſuƺyłem ſtopámi nóg mojich wƺyſtkie potoki oblężonych.
-Izáżeś nie ſłyƺał / żem ja zdáwná ucżynił á od dni ſtárodáwnych ſtworzyłem je? á teraz miáłżebym ná nie przywieść ſpuſtoƺenie / y obróćić w gromády gruzu ; jáko inƺe miáſtá obronne?
-Których obywátele ſtáli śię jáko bez rąk / przeſtráƺeni ſą y záwſtydzeni / bywƺy jáko tráwá polná / y jáko źiołá źielone / y tráwy po dáchách / które pierwej ſchną / niż śię doſtáją.
-Mieƺkánie twoje y wyjśćie twoje / y wejśćie twoje znam / tákże popędliwość twoję przećiwko mnie.
-Poniewáżeś śię przećiwko mnie zájuƺył / á zápędy twoje przyƺły do uƺu mojich / przetoż záłożę kolce moje zá nozdrzá twoje / á wędźidło moje wpráwię w gębę twoję / y wrócę ćię tą drogą / którąś przyƺedł /
-A to będźieƺ miał / Ezechyjáƺu! zá znák : Tego roku będźieƺ jádł ſámorodne zboże / y roku tákże drugiego ſámorodne zboże ; ále roku trzećiego będźiećie śiáć y żąć / y ſádźić winnice y jeść owoc ich.
-Oſtátek bowiem domu Judy / który pozoſtał / wkorzeni śię głęboko / y wydá owoc ku górze.
-Abowiem z Jeruzálemu wynijdą oſtátki / y ći / którzy ſą záchowáni z góry Syońſkiej. Gorliwość Páná zaſtępów to ucżyni.
-A przetoż ták mówi Pán o królu Aſſyryjſkim : Nie wnijdźie do miáſtá tego / áni tám dojdźie ſtrzáłá jego / áni go ubieży tárcżá / áni uſypie ƺáńców około niego ;
-Drogą / którą przyƺedł / wróći śię / á do miáſtá tego nie wnijdźie / mówi Pán.
-Bo będę bronił miáſtá tego / y záchowám je ſám dla śiebie / y dla Dawidá / ſługi mego.
-Y ſtáło śię oney nocy / że wyƺedł Anjoł Páńſki / á pobił w oboźie Aſſyryjſkim ſto ośmdźieśiąt y pięć tyśięcy. A gdy wſtáli ráno / oto wƺędy pełno trupów.
-Przetoż ruƺywƺy śię odjechał y wróćił śię Sennácheryb / król Aſſyryjſki á mieƺkał w Niniwe.
-A gdy chwálił bogá ſwego Neſrochá w domu / tedy Adrámelech y Sáráſſár / ſynowie jego / zábili go miecżem / á ſámi ućiekli do źiemi Arárát. Y królował Aſſárháddon / ſyn jego / miáſto niego.
+A gdy to uſłyƺał Król Ezechiaƺ / rozdárł ƺáty ſwoje / á oblekł śię w wór / y wƺedł do domu Páńſkiego.
+Y poſłał Eliákimá / ſprawcę domu <i>ſwego,</i> y Sobnę piſárzá / y ſtárƺe z Kápłanów / oblecżone w wory / do Ezájaƺá Proroká / Syná Amoſowego.
+Którzy rzekli do niego : Ták mówi Ezechiaƺ : Dźień utrapienia / y łájánia / y bluźnierſtwá / jeſt ten dźień : Abowiem Synowie przyƺli áż do porodzenia / á śiły niemáƺ ku rodzeniu.
+O by uſłyƺał PAN Bóg twój wƺyſtkie ſłowá Rábſáceſowe! którego przyſłał Król Aſſyryjſki Pan jego / urągáć Bogu żywemu / áby śię pomśćił onych ſłów / które ſłyƺał PAN Bóg twój. Przetoż ucżyń modlitwę zá te oſtátki / które śię znájdują.
+Przyƺli tedy ſłudzy Królá Ezechiaƺá do Ezájaƺá.
+Którym odpowiedźiał Ezájaƺ : Ták powiedzćie Pánu wáƺemu : To mówi PAN : Nie bój śię tych ſłów któreś ſłyƺał / którymi mię lżyli ſłudzy Królá Aſſyryjſkiego.
+Oto ja puƺcżę nań duchá / y uſłyƺy wieść / á wróći śię do źiemie ſwojey / y położę go miecżem w źiemi jego.
+Ale wróćiwƺy śię Rábſáces ználazł Królá Aſſyryjſkiego dobywájącego Lebny : ábowiem uſłyƺał / iż odćiągnął był od Láchis.
+A uſłyƺawƺy o Tiráku / Królu Etyopſkim / że mówiono : Oto wyćiągnął ná wojnę przećiwko tobie / znowu poſłał poſły do Ezechiaƺá / mówiąc :
+To powiedzćie Ezechiaƺowi Królowi Judſkiemu / mówiąc : Niech ćię nie zwodźi Bóg twój / któremu ty ufaƺ / á mówiƺ : Nie będźie podáne Jeruzalem w ręce Królá Aſſyryjſkiego :
+Otoś ſłyƺał co pocżynili Królowie Aſſyryjſcy wƺyſtkim źiemiam burząc je : á tybyś miał być wybáwiony?
+Izali wybáwili Bogowie narodów te które wygubili Ojcowie moji? Gozán / y Hárán / y Reſef / y Syny Eden / którzy byli w Teláſſár?
+Gdźież jeſt Król Emát / y Król Arfád / y Król miáſtá Sefárwájim / Aná y Awá?
+Przetoż wźiąwƺy Ezechiaƺ liſt z ręki poſłów / przecżytał go / y wƺedƺy do domu Páńſkiego / rozćiągnął go Ezechiaƺ przed PAnem.
+Y modlił śię Ezechiaƺ przed PAnem / mówiąc : PAnie Boże Izráelſki śiedzący ná Cherubinách / ty / tyś ſam jeſt Bóg wƺyſtkich króleſtw źiemie / tyś ſtworzył niebo y źiemię :
+Nákłońże PANie uchá twojego / á uſłyƺ : Otwórz PANie ocży twoje / á obacż / uſłyƺ ſłowá Sennácherybá / który przyſłał háńbić <i>ćiebie</i> Bogá żywego.
+Prawdáć jeſt PAnie / że ſpuſtoƺyli Królowie Aſſyryjſcy narody one / y źiemię ich :
+Y powrzucáli Bogi ich w ogień : Abowiem nie byli Bogowie / ále robotá rąk ludzkich / drewno / y kámień : Przetoż je wygubili.
+A teraz o PANIE Boże náƺ / wybaw nas / proƺę / z ręki jego / áby poznáły wƺyſtkie króleſtwá źiemie / żeś ty PANIE ſam Bogiem.
+Tedy poſłał Ezájaƺ Syn Amoſów do Ezechiaƺá / mówiąc : Ták mówi PAN Bóg Izráelſki : Ocoś mię prośił z ſtrony Sennácherybá Królá Aſſyryjſkiego / wyſłuchałem <i>ćię</i>.
+A teć ſą ſłowá które mówił PAN o nim : Pánná / Córká Syońſka / wzgárdźiłá ćię / śmiałá śię z ćiebie : Kiwáłá głową zá tobą córká Jeruzalemſka!
+Kogożeś háńbił / y kogoś bluźnił / przećiwko komużeś podnióſł głos / á wyniozłeś ku górze ocży ſwoje? przećiw świętemu Izráelſkiemu.
+Przez poſły twoje háńbiłeś PANA mego / y rzekłeś ; W mnóſtwie wozów mojich wſtąpiłem ná wyſokie góry / y ná ſtrony Libáńſkie / y podrąbię wyſokie Cedry jego / y wyborne jodły jego : y przydę áż do oſtátnich przybytków jego / do láſów / <i>y</i> wybornych ról jego.
+Jam wykopał <i>źrżódłá</i> y piłem wody cudze / á wyſuƺyłem ſtopámi nóg mojich wƺyſtkie potoki oblężonych.
+Izażeś nie ſłyƺał / żem je zdawná ucżynił / á od dni ſtárodawnych ſtworzyłem je? á teraz miałżebym ná nie przywieść ſpuſtoƺenie? y <i>obróćić</i> w gromády gruzu / <i>jáko inƺe</i> miáſtá obronne?
+Których obywátele ſtali śię jáko bez rąk / przeſtráƺeni ſą y záwſtydzeni / bywƺy jáko trawá polna / y jáko źiołá źielone / y trawy po dáchách / które pierwey ſchną / niż śię doſtáją.
+Mieƺkánie twoje y wyśćie twoje / y weśćie twoje / znam / tákże popędliwość twoję przećiwko mnie.
+Ponieważeś śię przećiwko mnie zájuƺył / á zapędy twoje przyƺły do uƺu mojich ; przetoż záłożę kolce moje zá nozdrzá twoje / á wędźidło moje <i>wpráwię</i> w gębę twoję / y wrócę ćię tą drogą / którąś przyƺedł.
+A to będźieƺ miał <i>Ezechiaƺu</i> zá znák : tego roku będźieƺ jadł ſámorodne <i>zboże,</i> y roku tákże drugiego / ſámorodne <i>zboże</i> : ále roku trzećiego będźiećie śiać y żąć / y ſádźić winnice / y jeść owoc jch.
+Oſtátek bowiem domu Judy / który pozoſtał / wkorzeni śię głęboko / y wyda owoc ku górze :
+Abowiem z Jeruzalem / wynidą oſtátki / y ći którzy ſą záchowáni z góry Syońſkiey. Gorliwość PANA zaſtępów to ucżyni.
+A przetoż ták mówi PAN o Królu Aſſyryjſkim : Nie wnidźie do miáſtá tego / áni tám dojdźie ſtrzałá jego / áni go ubieży tarcża / áni uſypie ƺáńców około niego :
+Drogą / którą przyƺedł / wróći śię / á do miáſtá tego nie wnidźie / mówi PAN.
+Bo będę bronił miáſtá tego / y záchowam je ſam dla śiebie / y dla Dawidá ſługi mego.
+Y ſtáło śię oney nocy że wyƺedł Anioł Páńſki / á pobił w oboźie Aſſyryjſkim / ſto ośmdźieśiąt y pięć tyśięcy. A gdy wſtáli ráno / oto wƺędy pełno trupów.
+Przetoż ruƺywƺy śię / odjáchał y wróćił śię Sennácheryb Król Aſſyryjſki / á mieƺkał w Niniwe.
+A gdy chwalił Bogá ſwego Neſrochá w domu / tedy Adrámelech y Sáráſſár / Synowie jego / zábili go miecżem : á ſámi ućiekli do źiemie Arárát. Y królował Aſſárháddon Syn jego / miáſto niego.


### PR DESCRIPTION
w.2;5-6;20 "Ezajaƺa" -> "Izajaƺa" por. KJV; niejednolita pisownia w tej księdze kontra np. księga Izajasza. Można wyszukać w całym tekście "Amosowego" i widać rozbieżność że raz syn Amosowy to Izajasz a raz Ezajasz. - dla 2 Król.19. zaadresowane w #2695, jednak możliwa konieczna zamiana w innych miejsach w tekście - najlepiej zamienić po ukończeniu digitalizacji 1632.
w.4. bardziej zdaje się pasować "Oby"; po "Rabsacesowe" raczej powinien być przecinek por. KJV.
w.16. niepewny przecinek po "ucha twojego"; KJV ma przecienk
w.22. "wyniozłeś" raczej literówka -> "wyniosłeś" w 1660 oraz reszcie tekstu 1632 dla sprawdzonych rozdziałów spotyka się pisownię przez "s"