### PR TITLE
2 Król.19,2;5-6;20

### DIFF
--- a/2023/12-reg/19.txt
+++ b/2023/12-reg/19.txt
@@ -1,0 +1,37 @@
+
+Y poſłał Eliákimá / ſprawcę domu <i>ſwego,</i> y Sobnę piſárzá / y ſtárƺe z Kápłanów / oblecżone w wory / do Izájaƺá Proroká / Syná Amoſowego.
+
+
+Przyƺli tedy ſłudzy Królá Ezechiaƺá do Izájaƺá.
+Którym odpowiedźiał Izájaƺ : Ták powiedzćie Pánu wáƺemu : To mówi PAN : Nie bój śię tych ſłów któreś ſłyƺał / którymi mię lżyli ſłudzy Królá Aſſyryjſkiego.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Tedy poſłał Izájaƺ Syn Amoſów do Ezechiaƺá / mówiąc : Ták mówi PAN Bóg Izráelſki : Ocoś mię prośił z ſtrony Sennácherybá Królá Aſſyryjſkiego / wyſłuchałem <i>ćię</i>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
w.2;5-6;20 "Ezajaƺa" -> "Izajaƺa" por. KJV + tekst masorecki + 1879; niejednolita pisownia w tej księdze kontra np. księga Izajasza. Można wyszukać w całym tekście "Amosowego" i widać rozbieżność że raz syn Amosowy to Izajasz a raz Ezajasz.
Razem z #2737 zamieniają wszystkie wystąpienia "Ezajasz" z 2 księgi królewskiej.

Sprawdziłem dodatkowo że w oryginale, tekście masoreckim, w 2 Król. oraz 2 Kron.26,22. i Izaj.39,3. występuje to samo słowo "ישעיהו", tak samo KJV i 1879 mają tam "Izajasz".