### PR TITLE
Ps.17.

### DIFF
--- a/1632/19-psa/017.txt
+++ b/1632/19-psa/017.txt
@@ -1,15 +1,15 @@
-Modlitwá Dawidowá. Wyſłucháj / Pánie! ſpráwiedliwość moję ; miej wzgląd ná wołánie moje ; przyjmij w uƺy modlitwę moję / którą cżynię uſty nieobłudnemi.
-Od oblicżnośći twojey ſąd mój niech wynijdźie ; ocży twoje niech pátrzą ná uprzejmość.
-Doświádcżyłeś ſercá mego / náwiedźiłeś je w nocy ; doświádcżyłeś mię ogniem / áleś nic nie ználázł ; myśli moje nie uprzedzáją uſt mojich.
-Co śię tknie ſpráw ludzkich według ſłowá uſt twojich / chroniłem śię drogi okrutniká.
-Zátrzymuj kroki moje ná drogách twych / áby śię nie chwiáły nogi moje.
-Ja ćię wzywám / bo mię wyſłuchiwáƺ / Boże! Nákłoń uchá twego ku mnie / wyſłucháj ſłowá moje.
-Okáż miłośierdźie twoje / ty / który ochrániáƺ ufájących w tobie od tych / którzy powſtáwáją przećiwko práwicy twojey.
-Strzeż mię jáko źrenicy oká ; pod ćieniem ſkrzydeł twojich ukryj mię.
-Przed twárzą niepobożnych / którzy mię niƺcżą / przed nieprzyjáćiółmi duƺy mojey / którzy mię ogárnęli.
-Tukiem ſwoim okryli śię ; hárdźie mówią uſty ſwemi.
-Gdźiekolwiek idźiemy / obtocżyli nas ; ocży ſwe náſádźili / áby nas potrąćili ku źiemi.
-Káżdy z nich podobien jeſt lwowi prágnącemu łupu / y lwięćiu śiedzącemu w jámie.
-Powſtáńże / Pánie! uprzedź twárz jego / potrąć go / wyrwij duƺę moję od niezbożnego miecżem twoim.
-Wyrwij mię od ludźi ręką twoją / o Pánie! od ludźi tego świátá / których dźiał jeſt w tym żywoćie / á których brzuch z ƺpiżárni twojey nápełniáƺ / ſkąd náſyceni bywáją / y ſynowie ich / á zoſtáwiáją oſtátki ſwoje dźiećiom ſwoim.
-Ale ja w ſpráwiedliwośći oglądám oblicże twoje ; gdy śię ocucę / náſycony będę obrázem oblicżnośći twojey.
+Modlitwá Dawidowá. Wyſłuchaj PAnie ſpráwiedliwość <i>moję</i> ; mij wzgląd ná wołánie moje : przyjmi w uƺy modlitwę moję / którą cżynię uſty nie obłudnymi.
+Od oblicżnośći twojey / ſąd mój niech wynidźie : ocży twoje niech pátrzą ná uprzyjmość.
+Doświadcżyłeś ſercá mego / náwiedźiłeś <i>je</i> w nocy : doświadcżyłeś mię ogniem / áleś nic nie ználazł : myśli <i>moje,</i> nie uprzedzáją uſt mojich.
+Co śię tknie ſpraw ludzkich / według ſłowá uſt twojich : chroniłem śię drogi okrutniká.
+Zátrzymawaj kroki moje ná drogách twych : áby śię nie chwiały nogi moje.
+Ja ćię wzywam / bo mię wyſłuchawaƺ Boże : nákłoń uchá twego ku mnie / wyſłuchaj ſłowá moje.
+Okaż miłośierdźie twoje ty / który ochraniaƺ dufájących w tobie / od tych / którzy powſtawáją przećiwko práwicy twojey.
+Strzeż mię jáko źrzenice oká : pod ćieniem ſkrzydeł twojich ukryj mię :
+Przed twarzą niepobożnych którzy mię niƺcżą <i>przed</i> nieprzyjaćióły duƺy mojey / którzy mię ogárnęli.
+Tukiem ſwojim okryli śię : hárdźie mówią uſty ſwymi.
+Gdźiekolwiek idźiemy obtocżyli nas : ocży ſwe náſádźili / áby nas potrąćili ku źiemi.
+Káżdy z nich podobiē jeſt lwowi prágnącemu łupu / y lwięćiu śiedzącemu w jámie.
+Powſtańże PAnie / uprzedź twarz jego / potrąć go : wyrwij duƺę moję od niezbożnego miecżem twojim.
+<i>Wyrwij mię</i> od ludźi ręką twoją o PAnie : od ludźi tego świátá ; których dźiał jeſt w tym żywoćie / á których brzuch z ƺpiżárnie twojey nápełniaƺ / z tąd náſyceni bywáją / y Synowie ich : á zoſtawiáją oſtátki ſwoje dźiećiom ſwojim.
+<i>Ale</i> ja w ſpráwiedliwośći oglądam oblicże twoje : Gdy śię ocucę náſycony będę obrázem <i>oblicżnośći</i> twojey.

--- a/1632/19-psa/017.txt
+++ b/1632/19-psa/017.txt
@@ -1,4 +1,4 @@
-Modlitwá Dawidowá. Wyſłuchaj PAnie ſpráwiedliwość <i>moję</i> ; mij wzgląd ná wołánie moje : przyjmi w uƺy modlitwę moję / którą cżynię uſty nie obłudnymi.
+Modlitwá Dawidowá. Wyſłuchaj PAnie ſpráwiedliwość <i>moję</i> ; mji wzgląd ná wołánie moje : przyjmji w uƺy modlitwę moję / którą cżynię uſty nie obłudnymi.
 Od oblicżnośći twojey / ſąd mój niech wynidźie : ocży twoje niech pátrzą ná uprzyjmość.
 Doświadcżyłeś ſercá mego / náwiedźiłeś <i>je</i> w nocy : doświadcżyłeś mię ogniem / áleś nic nie ználazł : myśli <i>moje,</i> nie uprzedzáją uſt mojich.
 Co śię tknie ſpraw ludzkich / według ſłowá uſt twojich : chroniłem śię drogi okrutniká.
@@ -6,10 +6,10 @@ Zátrzymawaj kroki moje ná drogách twych : áby śię nie chwiały nogi moje.
 Ja ćię wzywam / bo mię wyſłuchawaƺ Boże : nákłoń uchá twego ku mnie / wyſłuchaj ſłowá moje.
 Okaż miłośierdźie twoje ty / który ochraniaƺ dufájących w tobie / od tych / którzy powſtawáją przećiwko práwicy twojey.
 Strzeż mię jáko źrzenice oká : pod ćieniem ſkrzydeł twojich ukryj mię :
-Przed twarzą niepobożnych którzy mię niƺcżą <i>przed</i> nieprzyjaćióły duƺy mojey / którzy mię ogárnęli.
+Przed twarzą niepobożnych którzy mię niƺcżą <i>przed</i> nieprzyjaćioły duƺe mojey / którzy mię ogárnęli.
 Tukiem ſwojim okryli śię : hárdźie mówią uſty ſwymi.
 Gdźiekolwiek idźiemy obtocżyli nas : ocży ſwe náſádźili / áby nas potrąćili ku źiemi.
-Káżdy z nich podobiē jeſt lwowi prágnącemu łupu / y lwięćiu śiedzącemu w jámie.
+Káżdy z nich podobiē jeſt lwowi prágnącemu łupu / y lwięćiu śiędzącemu w jámie.
 Powſtańże PAnie / uprzedź twarz jego / potrąć go : wyrwij duƺę moję od niezbożnego miecżem twojim.
-<i>Wyrwij mię</i> od ludźi ręką twoją o PAnie : od ludźi tego świátá ; których dźiał jeſt w tym żywoćie / á których brzuch z ƺpiżárnie twojey nápełniaƺ / z tąd náſyceni bywáją / y Synowie ich : á zoſtawiáją oſtátki ſwoje dźiećiom ſwojim.
+<i>Wyrwji mię</i> od ludźi ręką twoją o PAnie : od ludźi tego świátá ; których dźiał jeſt w tym żywoćie / á których brzuch z ƺpiżárnie twojey nápełniaƺ / z kąd náſyceni bywáją / <i>y</i> Synowie ich : á zoſtawiáją oſtátki ſwoje dźiećiom ſwojim.
 <i>Ale</i> ja w ſpráwiedliwośći oglądam oblicże twoje : Gdy śię ocucę náſycony będę obrázem <i>oblicżnośći</i> twojey.

--- a/1632/19-psa/029.txt
+++ b/1632/19-psa/029.txt
@@ -1,11 +1,11 @@
-Pſálm Dawidowy. Oddáwájćie Pánu ſynowie mocárzów / oddáwájćie Pánu chwałę y moc.
-Oddáwájćie Pánu chwałę imienia jego ; kłániájćie śię Pánu w ozdobie świętobliwośći.
-Głos Páńſki nád wodámi ; Bóg chwálebny wzbudzá gromy / Pán nád wodámi wielkiemi.
-Głos Páńſki mocny / głos Páńſki wielmożny /
-Głos Páńſki cedry łámie ; kruƺy Pán cedry Libáńſkie /
-Y cżyni / że ſkácżą jáko ćielętá ; Libán y Syryjon jáko młody jednorożec.
-Głos Páńſki krzeƺe płomień ogniſty.
-Ná głos Páńſki z bólem puſtynie rodzą ; z bólem rodźi ná głos Páńſki puſtyniá Kádes.
-Ná głos Páńſki z bólem rodzą łánie / y odkrywáją śię láſy ; ále w kośćiele ſwym opowiádá wƺyſtkę chwałę ſwoję.
-Pán nád potopem śiedźiał / y będźie śiedźiał Pán / będąc królem ná wieki.
-Pán dodá mocy ludowi ſwojimu ; Pán będźie błogoſłáwił ludowi ſwemu w pokoju.
+Pſálm Dawidów. Oddawajćie PAnu Synowie mocárzów / oddawajćie PAnu chwałę y moc.
+Oddawajćie PAnu chwałę imienia jego : kłaniajćie śię PAnu / w ozdobie świętobliwośći.
+Głos PAńſki nád wodámi : Bóg chwalebny wzbudza gromy : PAN nád wodámi wielkimi.
+Głos PAńſki mocny / głos PAńſki wielmożny.
+Głos PAńſki Cedry łamie : kruƺy PAn cedry Libáńſkie.
+Y cżyni że ſkacżą jáko ćielętá : Liban y Syrion / jáko młody jednorożec.
+Głos PAńſki krzeƺe płomień ogniſty.
+<i>Ná</i> głos PAńſki z bólem puſtynie rodzą : z bólem rodźi <i>ná głos</i> PAńſki puſtynia Kádes.
+Ná głos PAńſki z bólem rodzą łánie / y odkrywáją śię láſy : ále w kośćiele ſwym opowiáda wƺyſtkę chwałę <i>ſwoję.</i>
+PAn nád potopem śiedźiał : y będźie śiedźiał PAn <i>będąc</i> Królem ná wieki.
+PAN doda mocy ludowi ſwojemu : PAn będźie błogoſłáwił ludowi ſwemu w pokoju.


### PR DESCRIPTION
w.8. w skanie czasem występuje dwuznak "rz" pisany jako "rż" - np słowo "źrzenice" - czy chcemy zostawiać tak jak w skanie "rż"?