### PR TITLE
2 Król.23.

### DIFF
--- a/1632/12-reg/23.txt
+++ b/1632/12-reg/23.txt
@@ -1,37 +1,37 @@
-Tedy poſłáwƺy król / áby śię zebráli do niego wƺyſcy ſtárśi Judzcy y Jeruzálemſcy /
-Wſtąpił król do domu Páńſkiego / y wƺyſcy mężowie Judzcy / y wƺyſcy obywátele Jeruzálemſcy z nim / y kápłáni / y prorocy / y wƺyſtek lud od máłego áż do wielkiego ; y cżytał / gdźie wƺyſcy ſłyƺeli wƺyſtkie ſłowá kśiąg przymierza / które były ználeźione w domu Páńſkim.
-Potem ſtánął król ná májeſtáćie / y ucżynił przymierze przed Pánem / że chce chodźić zá Pánem / y ſtrzedz rozkázánia jego / y świádectw jego / y wyroków jego ze wƺyſtkiego ſercá / y ze wƺyſtkiej duƺy / y pełnić ſłowá przymierza tego / które były nápiſáne w onych kśięgách. Y przeſtał lud ná onem przymierzu.
-Y przykázał król Helkijáƺowi / kápłánowi nájwyżƺemu / y kápłánom wtórego rzędu / y odźwiernym / áby wyrzućili z kośćiołá Páńſkiego wƺyſtko nacżynie / które ſpráwione było Báálowi / y gájowi poświęconemu / y wƺyſtkiemu wojſku niebieſkiemu / y ſpálił je precż zá Jeruzálemem ná polu Cedron / á zánióſł popiół ich do Betelá.
-Złożył też z urzędu popów / których byli poſtánowili królowie Judzcy / áby kádźili po wyżynách w miáſtách Judzkich y około Jeruzálemu ; przytem y onych / którzy kádźili Báálowi / ſłońcu y mieśiącowi / y plánetom / y wƺyſtkiemu wojſku niebieſkiemu.
-Kázał też wynieść gáj święcony z domu Páńſkiego precż z Jeruzálemu ku potokowi Cedron / á ſpálił go u potoku Cedron / y ſtárł go w proch / á popiół jego rozmiotał ná groby ſynów onegoż ludu.
-Zburzył też domy Sodomcżyków / które były w domu Páńſkim / kędy niewiáſty tkáły opony do gáju poświęconego.
-Y záwołał wƺyſtkich kápłanów z miaſt Judzkich / á ſplugáwił wyżyny / ná których kádźili / od Gábáá áż do Beerſebá / y popſuł wyżyny przy bramách / które były w wejśćiu bramy Jozuego / kśiążęćiá miáſtá / á było po lewej ſtronie wchodzącemu w bramę miejſką.
-Wƺákże nie przyſtępowáli kápłáni wyżyn do ołtárzá Páńſkiego w Jeruzálemie / ále jádáli chleby przáśne miedzy bráćmi ſwoimi.
-Splugáwił też y Tofet / które było w dolinie ſyná Hennomowego / áby więcey nikt nie przewodźił ſyná ſwego / áni córki ſwojey przez ogień ku cżći Molochowi.
-Zágubił też one konie / które byli królowie Judzcy oddáli ſłońcu / á ſtáły / kędy wchodzą do domu Páńſkiego / podle mieƺkánia Nátánmelechá dworzániná / które było ná przedmieśćiu ; y wozy ſłońcá ſpálił ogniem.
-Tákże ołtárze / które były ná dáchu ſáli Acházowej / które byli pocżynili królowie Judzcy / y ołtárze / które był pocżynił Mánáſes w obu śieniách domu Páńſkiego / pokáźił król ; á poſpieƺywƺy śię z támtąd kázał wrzućić proch ich w potok Cedron.
-Wyżyny tákże / które były przed Jeruzálem / y które były po práwej ſtronie góry Oliwney / których był nábudował Sálomon / król Izráelſki / Aſtárotowi / obrzydłośći Sydońcżyków / y Chámoſowi / obrzydłośći Moábcżyków / y Melchomowi / obrzydłośći ſynów Ammonowych / ſplugáwił król.
-Y pokruƺył ſłupy / á powyćinał gáje / y nápełnił miejſcá ich kośćiámi ludzkiemi.
-Nádto y ołtárz / który był w Betel / y wyżynę / którą był ucżynił Jeroboám / ſyn Nábátowy / który przywiódł do grzechu lud Izráelſki / y ten ołtárz / y wyżynę zepſuł / á ſpáliwƺy onę wyżynę / ſtárł ná proch / y ſpálił gáj.
-A obróćiwƺy śię Jozyjáƺ / obácżył groby / które tám były ná górze / á poſłáwƺy pobrał kośći z onych grobów / y popálił je ná tymże ołtárzu ; á ták go ſplugáwił według ſłowá Páńſkiego / które mówił mąż Boży / który był te rzecży przepowiedźiał.
-Y rzekł : Cóż to jeſt zá nápis / który widzę? Y odpowiedźieli mu mężowie miáſtá : Grób to mężá Bożego / który przyƺedƺy z Judy opowiedźiał te rzecży / któreś ucżynił nád ołtárzem w Betel.
-A on rzekł : Zániechájćie go / niecháj nikt nie ruchá kośći jego. Y wybáwili kośći jego / y kośći proroká onego / który był przyƺedł z Sámáryi.
-Wƺyſtkie też domy wyżyn / które były w miáſtách Sámáryjſkich / które byli pobudowáli królowie Izráelſcy / dráźniąc Páná / znióſł Jozyjáƺ / y ucżynił im według wƺyſtkiego / jáko był ucżynił w Betel.
-Pozábijał tákże wƺyſtkich kápłanów wyżyn / którzy tám byli ná ołtárzách / y pálił kośći ludzkie ná nich / potem śię wróćił do Jeruzálemu.
-Rozkázał też król wƺyſtkiemu ludowi / mówiąc : Obchodźćie święto przejśćiá Pánu / Bogu wáƺemu / jáko nápiſano w kśięgách przymierza tego.
-Bo nie obchodzono tákiego świętá przejśćiá ode dni ſędźiów / którzy ſądźili Izráelá / y przez wƺyſtkie dni królów Izráelſkich / y królów Judzkich.
-Jáko ośmnáſtego roku królá Jozyjáƺá / obchodzono tákie święto przejśćiá Pánu w Jeruzálemie.
-Ale y wieƺcżków / y cżárowników / y obrázy / y brzydkie báłwány / y wƺyſtkie obrzydłośći / co ich było widáć w źiemi Judzkiej y w Jeruzálemie / wykorzenił Jozyjáƺ / áby wypełnił ſłowá zakonu nápiſáne w kśięgách / które ználázł Helkijáƺ kápłán w domu Páńſkim.
-Y nie był podobny jemu król przed nim / któryby śię náwróćił do Páná z cáłego ſercá ſwego / y ze wƺyſtkiej duƺy ſwojey / y ze wƺyſtkiej śiły ſwojey / według wƺyſtkiego zakonu Mojżeƺowego / áni po nim powſtał jemu podobny.
-Wƺákże nie odwróćił śię Pán od popędliwośći wielkiego gniewu ſwego / którą był wzruƺony gniew jego przećiw Judźie dla wƺelkiego rozdráźnieniá / którem go był rozdráźnił Mánáſes.
-Przetoż rzekł Pán : Y Judę odrzucę od oblicżnośći mojey / jákom odrzućił Izráelá / y wzgárdzę to miáſto / którem był obrał / to jeſt Jeruzálem / y dom ten / o którymem mówił : Będźie tám imię moje.
-A inne ſpráwy Jozyjáƺowe / y wƺyſtko / co cżynił / opiſáno w kronikách o królách Judzkich.
-Zá dni jego wyćiągnął Fáráo Necho / król Egipſki / przećiw królowi Aſſyryjſkiemu ku rzece Eufrátes : wyjechał też król Jozyjáƺ przećiwko niemu / którego on zábił w Mágeddo / gdy go ujrzał.
-Y przywieſli go ſłudzy jego umárłego z Mágeddo / á przyprowádźili go do Jeruzálemu / y pogrzebli go w grobie jego. Potem wźiąwƺy lud oney źiemi Joácházá / ſyná Jozyjáƺowego / pomázáli go / y królem go poſtánowili miáſto ojcá jego.
-Dwádźieśćiá lat y trzy miał Joácház / gdy królowáć pocżął / á trzy mieśiące królował w Jeruzálemie. A imię mátki jego było Chámutál / córká Jeremijáƺowá z Lebny.
-Y cżynił złe przed ocżymá Páńſkimi według wƺyſtkiego / co cżynili ojcowie jego.
-Y związał go Fáráo Necho w Rebli w źiemi Emát / gdy królował w Jeruzálemie / á ułożył dáń ná onę źiemię ſto tálentów ſrebrá / y tálent złotá.
-A królem poſtánowił Fáráo Necho Elijákimá / ſyná Jozyjáƺowego / miáſto Jozyjáƺá / ojcá jego / y odmienił imię jego / á názwał go Joákim ; ále Joácházá wźiął / który / gdy przyƺedł do Egiptu / támże umárł.
-A to ſrebro y złoto dáwał Joákim Fáráonowi ; przetoż ƺácował źiemię / áby mógł oddáwáć ſrebro według rozkázánia Fáráonowego ; od káżdego według ƺácunku jego / brał ſrebro y złoto od ludu źiemi / áby je oddáwał Fáráonowi Nechowi.
-Dwádźieśćiá y pięć lat miał Joákim / gdy królowáć pocżął / á jedenaśćie lat królował w Jeruzálemie. A imię mátki jego było Zebudá / córká Fádájowá z Rumy.
-Y cżynił złe przed ocżymá Páńſkimi według wƺyſtkiego / jáko cżynili ojcowie jego.
+Tedy poſławƺy Król / áby śię zebráli do niego wƺyſcy ſtárƺy Judſcy y Jeruzalemſcy :
+Wſtąpił Król do domu Páńſkiego / y wƺyſcy mężowie Judſcy / y wƺyſcy obywátele Jeruzalemſcy z nim / y Kápłani / y Prorocy / y wƺyſtek lud / od máłego áż do wielkiego : y cżytał / gdźie wƺyſcy ſłyƺeli wƺyſtkie ſłowá Kśiąg przymierza / które były ználeźione w domu Páńſkim.
+Potym ſtánął Król ná májeſtaćie / y ucżynił przymierze przed PANEM / że chce chodźić zá PAnem / y ſtrzedz rozkazánia jego / y świádectw jego / y wyroków jego / ze wƺyſtkiego ſercá / y ze wƺyſtkiey duƺe : y pełnić ſłowá przymierza tego / które były nápiſáne w onych Kśięgách : y przeſtał lud ná onym Przymierzu.
+Y przykazał Król Helkiaƺowi Kápłanowi nawyżƺemu / y Kápłanom wtórego rzędu / y odźwiernym / áby wyrzućili z Kośćiołá Páńſkiego wƺyſtko nacżynie / które ſpráwiono było Báálowi / y gájowi <i>poświęconemu,</i> y wƺyſtkiemu wojſku niebieſkiemu / y ſpalił je precż zá Jeruzalem / ná polu Cedron / á zánióſł popiół ich do Bethelá.
+Złożył też <i>z urzędu</i> Popy / które byli poſtánowili królowie Judſcy / áby kádźili po wyżynách / w mieśćiech Judſkich / y około Jeruzalem : przytym y one / którzy kádźili Báálowi / ſłońcu y mieśiącowi / y Plánetom / y wƺyſtkiemu wojſku niebieſkiemu.
+Kazał też wynieść gaj <i>święcony</i> z domu Páńſkiego precż z Jeruzalem / ku potokowi Cedron / á ſpalił go u potoká Cedron / y ſtárł go w proch / á popiół jego rozmiotał ná groby Synów onegoż ludu.
+Zburzył też domy Sodomcżyków / które były w domu PAŃſkim / kędy niewiáſty tkáły opony do gáju <i>poświęconego</i>.
+Y zwołał wƺyſtkich Kápłanów z miaſt Judſkich / á ſplugáwił wyżyny ná których kádźili / od Gábáá áż do Beerſebá / y popſował wyżyny przy bramách / które <i>były</i> w weśćiu bramy Jozuego / Kśiążęćiá miáſtá : á <i>były</i> po lewey ſtronie wchodzącemu w bramę miejſką.
+Wƺákże nie przyſtępowáli kápłani wyżyn do Ołtarzá Páńſkiego w Jeruzalem : ále jadáli chleby przáſne miedzy bráćią ſwoją.
+Zplugáwił też y Tofet / które było w dolinie Syná Hennomowego / áby więcey nikt nie przewodźił Syná ſwego / áni córki ſwojey przez ogień <i>ku cżći</i> Molochowi.
+Zágubił też one konie / które byli Królowie Judſcy oddáli Słońcu / <i>á ſtáły</i> kędy wchodzą do domu Páńſkiego / podle mieƺkánia Nátánmelechá dworzániná / które było ná przedmieśćiu : y wozy Słońcá ſpalił ogniem.
+Tákże Ołtarze / które były ná dáchu Sali Acházowey / które byli pocżynili Królowie Judſcy / y Ołtarze które był pocżynił Mánáſſes / w obu śieniách domu PAńſkiego / pokáźił Król : á poſpieƺywƺy śię z támtąd / kazał wrzućić proch ich w potok Cedron.
+Wyżyny tákże / które były przed Jeruzalem / y które były po práwey ſtronie góry oliwney / których był nábudował Sálomon Król Izráelſki Aſtárotowi obrzydłośći Sydońcżyków / y Chámoſowi obrzydłośći Moábcżyków / y Melchomowi obrzydłośći Synów Ammonowych / ſplugáwił Król.
+Y pokruƺył ſłupy / á powyćinał gáje / y nápełnił miejſcá ich kośćiámi ludzkimi.
+Nád to y Ołtarz / który był w Bethel / <i>y</i> wyżynę którą był ucżynił Jeroboám / Syn Nábátów / który przywiódł do grzechu lud Izráelſki : y ten Ołtarz / y wyżynę zepſował / á ſpaliwƺy one wyżynę ſtárł ná proch / y ſpalił gaj.
+A obróćiwƺy śię Jozyaƺ / obacżył groby / które tám były ná górze / á poſławƺy / pobrał kośći z onych grobów / y popalił je ná tymże Ołtarzu : á ták go ſplugáwił według ſłowá Páńſkiego / które mówił mąż Boży / który był te rzecży przedpowiedźiał.
+Y rzekł : Cóż to jeſt zá napis który widzę? Y odpowiedźieli mu mężowie miáſtá : Grób to mężá Bożego / który przyƺedƺy z Judy / opowiedźiał te rzecży któreś ucżynił nád Ołtarzem w Bethel.
+A on rzekł : Zániechajćie go / niechaj nikt nie rucha kośći jego. Y wybáwili kośći jego / y kośći Proroká onego który był przyƺedł z Sámáryjey.
+Wƺyſtkie też domy wyżyn które były w mieśćiech Sámáryjſkich / które byli pobudowáli Królowie Izráelſcy / draźniąc <i>PANA</i> znióſł Jozyaƺ / y ucżynił im według wƺyſtkiego jáko był ucżynił w Bethel.
+Pozábijał tákże wƺyſtkie Kápłany wyżyn / którzy tám <i>byli</i> ná Ołtarzách / y palił kośći ludzkie ná nich. Potym śię wróćił do Jeruzalem.
+Rozkazał też Król wƺyſtkiemu ludowi / mówiąc : Obchodźćie święto Prześćia PAnu / Bogu wáƺemu / jáko nápiſano w Kśięgách przymierza tego.
+Bo nie obchodzono tákiego świętá Prześćia ode dni Sędźiów którzy ſądźili Izráelá / y przez wƺyſtkie dni Królów Izráelſkich / y Królów Judſkich :
+Jáko ośmnaſtego roku Królá Jozyaƺá / obchodzono tákie święto Prześćia PAnu / w Jeruzalem.
+Ale y wieƺcżki / y cżárowniki / y obrázy / y brzydkie báłwany / y wƺyſtkie obrzydłośći co ich było widáć w źiemi Judſkiey / y w Jeruzalemie / wykorzenił Jozyaƺ : áby wypełnił ſłowá zakonu nápiſáne w Kśięgách / które ználazł Helkiaƺ Kápłan w domu PAńſkim.
+Y nie był podobny jemu Król przed nim / któryby śię náwróćił do PANA z cáłego ſercá ſwego / y ze wƺyſtkiey duƺe ſwojey / y ze wƺyſtkiey śiły ſwojey / według wƺyſtkiego Zakonu Mojzeƺowego / áni po nim powſtał jemu podobny.
+Wƺákże nie odwróćił śię PAN od popędliwośći wielkiego gniewu ſwego / którą był wzruƺony gniew jego przećiw Judźie / dla wƺelkiego rozdraźnienia / którym go był rozdraźnił Mánáſſes.
+Przetoż rzekł PAN ; y Judę odrzucę od oblicżnośći mojey / jákom odrzućił Izráelá / y wzgárdzę to miáſto / którem był obrał : <i>to jeſt</i> Jeruzalem / y dom ten / o którymem mówił ; Będźie tám imię moje.
+A inne ſpráwy Jozyaƺowe / y wƺyſtko co cżynił / opiſano w Kronikách o Królách Judſkich.
+Zá dni jego wyćiągnął Fáráo Necho / Król Egipſki przećiw królowi Aſſyryjſkiemu / ku rzece Eufrátes : wyjáchał też Król Jozyaƺ przećiwko niemu / którego <i>on</i> zábił w Mágeddo gdy go ujrzał.
+Y przywieźli go ſłudzy jego umárłego z Mágeddo / á przyprowádźili go do Jeruzalem / y pogrzebli go w grobie jego. Potym wźiąwƺy lud oney źiemie Joácházá / Syná Jozyaƺowego pomázáli go ; Y Królem go poſtánowili miáſto Ojcá jego.
+Dwádźieśćiá lat y trzy miał Joácház / gdy królowáć pocżął : á trzy mieśiące królował w Jeruzalem. A imię mátki jego było Chámutál córká Jeremiaƺowá z Lebny.
+Y cżynił złe przed ocżymá PAŃſkimi / według wƺyſtkiego co cżynili Ojcowie jego.
+Y związał go Fáráo Necho w Rebli / w źiemi Emát / gdy królował w Jeruzalemie : á ułożył dań ná onę źiemię / ſto talentów śrebrá / y talent złotá.
+A Królem poſtánowił Fáráo Necho / Eliákimá Syná Jozyaƺowego / miáſto Jozyaƺá Ojcá jego / y odmienił imię jego / <i>á názwał go</i> Joákim : ále Joácházá wźiął / który gdy przyƺedł do Egiptu támże umárł.
+A to śrebro / y złoto / dawał Joákim Fáráonowi : przetoż ƺácował źiemię / áby mógł oddawáć śrebro według rozkazánia Fáráonowego ; od káżdego według ƺácunku jego / <i>brał</i> śrebro y złoto od ludu źiemie / áby je oddawał Fáráonowi Nechowi.
+Dwádźieśćiá y pięć lat miał Joákim / gdy królowáć pocżął / á jedenaśćie lat królował w Jeruzalem. A imię mátki jego było Zebudá / córká Fádájowá z Rumy.
+Y cżynił złe przed ocżymá Páńſkimi / według wƺyſtkiego jáko cżynili Ojcowie jego.


### PR DESCRIPTION
w.5. po słowie "Judſcy" niewyraźny przecinek; 1660 ma "/"
w.15. "one" -> "onę" sprawdziłem inne wystąpienia w 1632 że mają formę "onę" dla sprawdzonych rozdziałów.
//
nie powiązane z wprowadzanymi tu zmianami - ogólnie w tekście występuje "ō", zauważyłem że jego zamiana na pełny wyraz nie jest zawsze taka sama np. "ō" -> "om" lub "ō" -> "on"