### PR TITLE
2 Król.20,1;4;7-9;11;14;16;19

### DIFF
--- a/2023/12-reg/20.txt
+++ b/2023/12-reg/20.txt
@@ -1,0 +1,21 @@
+W one dni záchorzał Ezechiaƺ áż ná śmierć / y przyƺedł do niego Izájaƺ Prorok / Syn Amoſów / y rzekł mu : Ták mówi PAN : Rozpraw dom twój / bo umrzeƺ / á nie będźieƺ żyw.
+
+
+Ale jeƺcże Izájaƺ nie wyƺedł był do pół śieni / gdy śię ſłowo PAŃſkie ſtáło do niego / mówiąc :
+
+
+Przytym rzekł Izájaƺ ; Przynieśćie bryłę fig ſuchych / którą przyniózƺy włożyli ná wrzód / y zgojił śię.
+Y rzekł Ezechiaƺ do Izájaƺá : Jáki znák <i>tego</i> że mię uzdrowi PAN / á iż pójdę dniá trzećiego do domu Páńſkiego?
+Odpowiedźiał Izájaƺ : Toć <i>będźie</i> znákiem od PANA / iż ucżyni PAN tę rzecż którąć obiecał. <i>Chceƺże</i> żeby ćień poſtąpił ná dźieśięć ſtopniów / álbo żeby śię ná wſtecż wróćił ná dźieśięć ſtopniów?
+
+Tedy wołał Izájaƺ Prorok do PANA : y náwróćił ćień po onych ſtopniách / którymi był poſtąpił ná zegárze ſłonecżnym Acházowym / ná wſtecż ná dźieśięć ſtopniów.
+
+
+Przetoż przyƺedł Prorok Izájaƺ do Królá Ezechiaƺá / y rzekł mu : Coć powiedźieli ći mężowie : á z kąd przyƺli do ćiebie? Y odpowiedźiał Ezechiaƺ : Z źiemie dálekiey przyƺli / z Bábilonu.
+
+Ale Izájaƺ rzekł do Ezechiaƺá : Słuchaj ſłowá Páńſkiego.
+
+
+Tedy rzekł Ezechiaƺ do Izájaƺá : Dobre jeſt ſłowo Páńſkie / któreś mówił. Nád to rzekł : Zájiſte <i>dobre</i> ; jeſli tylko pokój y prawdá będźie zá dni mojich.
+
+


### PR DESCRIPTION
"Ezajaƺa" -> "Izajaƺa" por. KJV + tekst masorecki + 1879; niejednolita pisownia w tej księdze kontra np. księga Izajasza. Można wyszukać w całym tekście "Amosowego" i widać rozbieżność że raz syn Amosowy to Izajasz a raz Ezajasz. Powiązany PR: #2695.