### PR TITLE
2 Król.25.

### DIFF
--- a/1632/12-reg/25.txt
+++ b/1632/12-reg/25.txt
@@ -1,30 +1,30 @@
-Y ſtáło śię roku dźiewiątego królowánia jego / mieśiącá dźieśiątego / dniá dźieśiątego tegoż mieśiącá / że przyćiągnął Nábuchodonozor / król Bábilońſki / on y wƺyſtko wojſko jego przećiw Jeruzálemowi / y położył śię obozem u niego / á porobił przećiwko niemu ƺáńce w około.
-A ták oblężone było miáſto áż do jedenáſtego roku królá Sedekijáƺá.
-Tedy dniá dźiewiątego cżwártego mieśiącá był wielki głód w mieśćie / y nie miał chlebá lud źiemi.
-Y przełámáno mur miejſki / á wƺyſcy ludźie rycerſcy ućiekli w nocy drogą / kędy idą do bramy / która jeſt miedzy dwomá murámi / które były podle ogrodu królewſkiego ; á Cháldejcżycy leżeli około miáſtá / á król uƺedł drogą do puſtyni.
-Y goniło wojſko Cháldejſkie królá / y pojmáło go ná polách Jerycho ; á wƺyſtko wojſko jego rozpierzchnęło śię od niego.
-A ták pojmáwƺy królá przywiedli go do królá Bábilońſkiego do Rebli / kędy o nim ucżynili ſąd.
-A ſynów Sedekijáƺowych pozábijáli przed ocżymá jego ; potem Sedekijáƺá oślepiwƺy związáli go łáńcuchámi miedźiánemi / y záwiedli go do Bábilonu.
-Potem mieśiącá piątego / śiódmego dniá tegoż mieśiącá / ( ten jeſt rok dźiewiętnáſty królowánia Nábuchodonozorá / królá Bábilońſkiego ) przyćiągnął Nábuzárdán / hetmán żołnierſki / ſługá królá Bábilońſkiego / do Jeruzálemu ;
-Y ſpálił dom Páńſki / y dom królewſki / y wƺyſtkie domy w Jeruzálemie / owá wƺyſtko budowánie koƺtowne popálił ogniem.
-Mury tákże Jeruzálemſkie w około rozwáliło wƺyſtko wojſko Cháldejſkie / które było z onym hetmánem żołnierſkim.
-A oſtátek ludu / który był zoſtał w mieśćie / y zbiegi / którzy zbiegli byli do królá Bábilońſkiego / y inne poſpólſtwo / przenióſł Nábuzárdán / hetmán żołnierſki.
-Tylko z ubogich oney źiemi zoſtáwił hetmán żołnierſki / áby byli winiárzámi y orácżámi.
-Nádto ſłupy miedźiáne / które były w domu Páńſkim / y podſtáwki / y morze miedźiáne / które było w domu Páńſkim / potłukli Cháldejcżycy / y przenieśli wƺyſtkę miedź do Bábilonu.
-Kotły też y łopáty / y nacżynia muzycżne / y miſy y wƺyſtko nacżynie miedźiáne / którem uſługiwano ; pobráli.
-Y kádźielnice / y miednice / y co było złotego w złoćie / y co było ſrebrnego w ſrebrze / pobrał hetmán żołnierſki.
-Słupy dwá / morze jedno / y podſtáwki / które był ſpráwił Sálomon w domu Páńſkim / á nie było wági miedźi onego wƺyſtkiego nacżynia.
-Ośmnaśćie łokći wzwyż było ſłupá jednego / á gáłká ná nim miedźiáná ; á gáłká miáłá ná wzwyż trzy łokćie / á śiátká y jábłká gránátowe ná gáłce w około / wƺyſtko miedźiáne. Tákiż też był y drugi ſłup z śiátką /
-Wźiął też hetmán żołnierſki Sárájego / kápłáná przedniego / y Sofonijáƺá / kápłáná wtórego / y trzech odźwiernych.
-Wźiął też z miáſtá dworzániná jednego / który był przełożony nád ludem rycerſkim / y pięć mężów z tych / którzy ſtáwáli przed królem / którzy byli ználeźieni w mieśćie / y piſárzá przedniego wojſkowego / który ſpiſywał lud oney źiemi / y ƺeśćdźieśiąt mężów z ludu źiemi / którzy śię ználeſli w mieśćie.
-Pojmáwƺy ich tedy Nábuzárdán / hetmán żołnierſki / záwiódł ich do królá Bábilońſkiego do Rybláty.
-Y pobił ich król Bábilońſki / á pomordował ich w Rybláćie w źiemi Emát ; á ták przenieśiony jeſt Judá z źiemi ſwojey.
-Ale nád ludem / który jeƺcże był zoſtał w źiemi Judzkiej / którego był zoſtáwił Nábuchodonozor / król Bábilońſki / przełożył Godolijáƺá / ſyná Ahykámowego / ſyná Sáfánowego.
-A gdy uſłyƺeli wƺyſcy hetmáni wojſká / ſámi y mężowie ich / że przełożył król Bábilońſki Godolijáƺá / tedy przyƺli do Godolijáƺá do Máſfy ; miánowićie / Izmáel / ſyn Nátánijáƺowy / y Johánán / ſyn Káreáƺowy / y Serájáƺ / ſyn Tánhumetá Netofátcżyká / y Jezonijáƺ / ſyn Mááchátowy / ſámi y mężowie ich.
-Którym przyśiągł Godolijáƺ / y mężom ich / y rzekł im : Nie bójćie śię być poddánymi Cháldejcżykom ; zoſtáńćie w źiemi / á ſłużćie królowi Bábilońſkiemu / y będźie wam dobrze.
-Y ſtáło śię mieśiącá śiódmego / że przyƺedł Izmáel / ſyn Nátánijáƺá / ſyná Eliſámowego / z náśieniá królewſkiego / y dźieśięć mężów z nim / y zábili Godolijáƺá / y umárł ; tákże Żydów y Cháldejcżyków / którzy z nim byli w Máſfá.
-Tedy powſtał wƺyſtek lud od máłego áż do wielkiego / y hetmáni wojſk / á poƺli do Egiptu ; bo śię báli Cháldejcżyków.
-Stáło śię tákże trzydźieſtego y śiódmego roku pojmánia Joáchyná / królá Judzkiego / dwunáſtego mieśiącá dniá dwudźieſtego śiódmego tegoż mieśiącá / że wywyżƺył Ewilmerodách / król Bábilońſki / tegoż roku / gdy pocżął królowáć / głowę Joáchyná / królá Judzkiego / uwolniwƺy go z więźieniá.
-Y rozmáwiał z nim łáſkáwie / á wyſtáwił ſtolicę jego nád ſtolicę innych królów / którzy z nim byli w Bábilonie.
-Odmienił też odźienie jego / w którym był w więźieniu / y jádał chleb záwƺe przed oblicżem jego po wƺyſtkie dni żywotá ſwego.
-Obrok też jemu náznácżony uſtáwicżnie mu dáwano od królá / ná káżdy dźień po wƺyſtkie dni żywotá jego.
+Y ſtáło śię roku dźiewiątego / królowánia jego / mieśiącá dźieśiątego / <i>dniá</i> dźieśiątego <i>tegoż</i> mieśiącá / że przyćiągnął Nábuchodonozor Król Bábilońſki / on y wƺyſtko wojſko jego / przećiw Jeruzalem / y położył śię obozem u niego / á porobił przećiwko niemu ƺáńce w około.
+A ták oblężone było miáſto / áż do jedenaſtego roku Królá Sedekiaƺá.
+Tedy dniá dźiewiątego / <i>cżwartego</i> mieśiącá / był wielki głód w mieśćie / y nie miał chlebá lud źiemie.
+Y przełamano mur miejſki / á wƺyſcy ludźie rycerſcy <i>ućiekli</i> w nocy drogą / kędy idą do bramy / która jeſt miedzy dwiemá murámi / które były podle ogrodu królewſkiego : á Cháldejcżycy leżeli około miáſtá : á <i>Król</i> uƺedł drogą do puſtyniey.
+Y goniło wojſko Cháldejſkie Królá / y pojimáło go / ná polách Jerycho : á wƺyſtko wojſko jego rozpierzchnęło śię od niego.
+A ták pojimawƺy Królá / przywiedli go do Królá Bábilońſkiego / do Reble / kędy o nim ucżynili ſąd.
+A Syny Sedekiaƺowe pozábijáli przed ocżymá jego : potym Sedekiaƺá oślepiwƺy / związáli go łáncuchámi miedźiánymi / y záwiedli go do Bábilonu.
+Potym mieśiącá piątego / śiódmego <i>dniá</i> tegoż mieśiącá / ( ten jeſt rok dźiewiętnaſty królowánia Nábuchodonozorá Królá Bábilońſkiego ) przyćiągnął Nábuzárdán Hetman żołnierſki / ſługá Królá Bábilońſkiego do Jeruzalem.
+Y ſpalił dom Páńſki / y dom królewſki / y wƺyſtkie domy w Jeruzalem : owa wƺyſtko budowánie koƺtowne popalił ogniem.
+Mury tákże Jeruzalemſkie w około rozwáliło wƺyſtko wojſko Cháldejſkie / które było z onym Hetmánem żołnierſkim.
+A oſtátek ludu / który był zoſtał w mieśćie / y zbiegi którzy zbiegli byli do Królá Bábilońſkiego / y inne poſpólſtwo / przenióſł Nábuzárdán Hetman żołnierſki.
+Tylko z ubogich oney źiemie zoſtáwił Hetman żołnierſki / áby byli winiarzámi y oracżámi.
+Nád to ſłupy miedźiáne / które były w domu Páńſkim / y podſtáwki / y morze miedźiáne / które było w domu Páńſkim potłukli Cháldejcżycy / y przenieśli wƺyſtkę miedź do Bábilonu.
+Kotły też y łopáty / y nacżynia muzycżne / y miſy / y wƺyſtko nacżynie miedźiáne / którym uſługowano / pobráli.
+Y kádźilnice / y miednice / y co było złotego w złoćie / y co było śrebrnego w śrebrze / pobrał Hetman żołnierſki.
+Słupy dwá / morze jedno / y podſtáwki / które był ſpráwił Sálomon / w domu Páńſkim / <i>á</i> nie było wagi miedźi onego wƺyſtkiego nacżynia.
+Ośmnaśćie łokći wzwyƺ było ſłupá jednego / á gałká ná nim miedźiána : á gałká miáłá ná wzwyƺ trzy łokćie / á śiatká y jábłká gránatowe ná gałce w około / wƺyſtko miedźiáne. Tákiż też był y drugi ſłup z śiatką.
+Wźiął też Hetman żołnierſki / Sárájego kápłaná przedniego / y Sofoniaƺá Kápłaná wtórego / y trzech odźwiernych.
+Wźiął też z miáſtá dworzániná jednego / który był przełożony nád ludem rycerſkim / y pięć mężów z tych którzy ſtawáli przed Królem / którzy byli ználeźieni w mieśćie : y piſárzá przedniego wojſkowego / który ſpiſował lud oney źiemie : y ƺeśćdźieśiąt mężów z ludu źiemie / którzy śię ználeźli w mieśćie.
+Pojimawƺy je tedy Nábuzárdán / Hetman żołnierſki / záwiódł je do Królá Bábilońſkiego / do Rybláty.
+Y pobił je Król Bábilońſki / á pomordował je w Rybláćie / w źiemi Emát : á ták przenieśiony jeſt Judá z źiemie ſwojey.
+Ale nád ludem / który jeƺcże był zoſtał w źiemi Judſkiey / którego był zoſtáwił Nábuchodonozor Król Bábilońſki / przełożył Godoliaƺá / Syná Ahikámowego / Syná Sáfánowego.
+A gdy uſłyƺeli wƺyſcy Hetmáni wojſká / ſámi y mężowie ich / że przełożył Król Bábilońſki Godoliaƺá / tedy przyƺli do Godoliaƺá do Máſfy : miánowićie / Izmáel Syn Nátániaƺów / y Johánán Syn Káreaƺów / y Serájaƺ Syn Tánhumetá Netofátcżyká / y Jezoniaƺ Syn Mááchátów / ſámi y mężowie ich.
+Którym przyśiągł Godoliaƺ / y mężom ich / y rzekł im : Nie bójćie śię bydź poddánymi Cháldejcżykom / zoſtańćie w źiemi / á ſłużćie Królowi Bábilońſkiemu / y będźie wam dobrze.
+Y ſtáło śię mieśiącá śiódmego / że przyƺedł Izmáel Syn Nátániaƺá / Syná Eliſámowego / z naśienia królewſkiego / y dźieśięć mężów z nim : y zábili Godoliaƺá / y umárł : tákże żydy / y Cháldejcżyki / którzy z nim byli w Másfá.
+Tedy powſtał wƺyſtek lud / od máłego áż do wielkiego / y Hetmáni wojſk / á poƺli do Egiptu / bo śię bali Cháldejcżyków.
+Stáło śię tákże / trzydźieſtego y śiódmego roku / pojimánia Joáchiná / Królá Judſkiego / dwunaſtego mieśiącá / <i>dnia</i> dwudźieſtego śiódmego / tegoż mieśiącá / że wywyżƺył Ewilmerodách Król Bábilońſki / tegoż roku / gdy pocżął królowáć / głowę Joáchiná Królá Judſkiego / <i>uwolniwƺy go</i> z więźienia.
+Y rozmawiał z nim łáſkáwie / á wyſtáwił ſtolicę jego nád ſtolice innych Królów / którzy z nim <i>byli</i> w Bábiloniey.
+Odmienił też odźienie jego w którym był w więźieniu / y jadał chleb záwƺe przed oblicżem jego po wƺyſtkie dni żywotá ſwego.
+Obrok też jemu náznácżony / uſtáwicżnie mu dawano od Królá / ná káżdy dźień / po wƺyſtkie dni żywotá jego.


### PR DESCRIPTION
w.28. "stolice innych" -> KJV + 1879 + tekst masorecki mają l.poj. "stolicę innych" - zaadresowane w #2745.

powtarzają się zamiany:
"pojma*" -> "pojima*"; np. "pojimany"
"łańcuch*" -> "łancuch*", choć "łańcuszek" jest pisane przez "ń"