### PR TITLE
Ps.68.

### DIFF
--- a/1632/19-psa/068.txt
+++ b/1632/19-psa/068.txt
@@ -1,36 +1,36 @@
-Przedniejƺemu śpiewákowi pſálm Dawidowy ku śpiewániu.
-Powſtánie Bóg / á będą rozproƺeni nieprzyjáćiele jego / y poućiekáją przed twárzą jego ći / którzy go máją w nienáwiśći.
-Jáko bywa dym rozpędzony / ták ich rozpędzáƺ : jáko śię woſk rozpływá od ogniá / ták niezbożnicy poginą przed oblicżem Bożem.
-Ale ſpráwiedliwi weſelić śię y rádowáć będą przed oblicżem Bożem / y pląſáć będą od rádośći.
-Śpiewájćie Bogu / śpiewájćie pſálmy imieniowi jego ; gotujćie drogę temu / który jeźdźi ná obłokách. Pán jeſt imię jego / rádujćież śię przed oblicżem jego.
-Ojcem jeſt śierót / y ſędźią wdów / Bogiem w przybytku ſwym świętym.
-Bóg / który ſámotne w rodowite domy rozmnáżá / wywodźi więźniów z oków ; ále odporni mieƺkáć muƺą w źiemi ſuchej.
-Boże! gdyś wychodźił przed oblicżem ludu twego / gdyś chodźił po puƺcży ; Selá /
-Ziemiá śię trzęſłá / tákże y niebioſá rozpływáły śię przed oblicżem Bożem / y tá górá Synáj drżáłá przed twárzą Bogá / Bogá Izráelſkiego.
-Deƺcż obfity ſpuƺcżáłeś hojnie / o Boże! ná dźiedźictwo twoje / á gdy omdlewáło / tyś je záś otrzeźwiał.
-Záſtępy twoje mieƺkáją w nim / któreś ty dla ubogiego nágotował dobroćią twoją / o Boże!
-Pán dał ſłowo ſwe / y tych / którzy poćiechy zwiáſtowáli / záſtęp wielki mówiących.
-Królowie z wojſkámi ućiekáli / ućiekáli : ále tá / która przyglądáłá domu / dźieliłá łupy.
-Choćiáżeśćie leżeć muśieli miedzy kotłámi / przećież będźiećie jáko gołębicá / májącá piórá poſrebrzone / á którey ſkrzydłá jáko żółte złoto.
-Gdy Wƺechmogący rozproƺy królów w tey źiemi / wybielejeƺ jáko śnieg ná górze Sálmon.
-Ná górze Bożey / ná górze Báſáńſkiej / ná górze págórcżyſtey / ná górze Báſáńſkiej.
-Przecżże wyſkákujećie góry págórcżyſte? ná tejći górze ulubił ſobie Bóg mieƺkánie / támći Pán będźie mieƺkał ná wieki.
-Wozów Bożych jeſt dwádźieśćiá tyśięcy / wiele tyśięcy Aniołów ; ále Pán miedzy nimi jáko ná Synáj w świątnicy przebywá.
-Wſtąpiłeś ná wyſokość / wiodłeś pojmánych więźniów / nábráłeś dárów dla ludźi / y nájodporniejƺych / Pánie Boże! przywiodłeś / áby mieƺkáli z námi.
-Błogoſłáwiony Pán ; ná káżdy dźień hojnie nas opátruje dobrámi ſwemi Bóg zbáwieniá náƺego. Selá.
-On jeſt Bóg náƺ / Bóg obfitego zbáwieniá ; pánujący Pán z śmierći wywodźi.
-Zájiſte Bóg zráni głowę nieprzyjáćiół ſwojich / y wierzch głowy włoſámi nákryty chodzącego w grzechách ſwojich.
-Rzekł Pán : Wyprowádzę záś ſwojich jáko z Báſán / wywiodę ich záś z głębokośći morſkiej.
-Przetoż będźie nogá twojá zbrocżoná we krwi / y język pſów twojich we krwi nieprzyjáćielſkiej.
-Widźieli ćiągnieniá twoje / Boże! ćiągnieniá Bogá mego y królá mego w świątnicy.
-Wprzód ƺli śpiewácy / á zá nimi grájący ná inſtrumentách / á w pośrzodku pánienki bijąc w bębny.
-W zgromádzeniách błogoſłáwćie Bogu / błogoſłáwćie Pánu / którzyśćie z narodu Izráelſkiego. Tu niech będźie Benjámin málucżki / który ich opánował ;
-Tu kśiążętá Judzcy / y hufy ich / kśiążętá Zábulońſcy / y kśiążętá Neftálimſcy.
-Obdárzył ćię Bóg twój śiłą ; utwierdź / o Boże! to / coś w nas ſpráwił.
-Dla kośćiołá twego / który jeſt w Jeruzálemie / będąć królowie dáry przynośić.
-Poráź pocżet kopijników / zgromádzenie mocnych wodzów / y ludu bujnego / hárdych / chlubiących śię kęſem ſrebrá ; rozproƺ narody prágnące wojny.
-Przyjdąć zácni kśiążętá z Egiptu : Murzyńſká źiemiá poſpieƺy śię wyćiągnąć ręce ſwe do Bogá.
-Króleſtwá źiemi! śpiewájćież Bogu / śpiewájćie Pánu. Selá.
-Temu / który jeźdźi ná nájwyżƺych niebioſách od wiecżnośći ; oto wydáje głos ſwój / głos mocy ſwojey.
-Przyznájćie moc Bogu / nád Izráelem doſtojność jego / á wielmożność jego ná obłokách.
-Stráƺnyś jeſt / o Boże! z świętych przybytków twojich ; Bóg Izráelſki ſám dáje moc y śiły ludowi ſwemu. Niechájże będźie Bóg błogoſłáwiony.
+Przedniejƺemu śpiewakowi / Pſálm Dawidów ku śpiewániu.
+Powſtánie Bóg / á będą rozproƺeni nieprzyjaćiele jego : y zućiekáją przed twarzą jego ći / którzy go máją w nienawiśći.
+Jáko bywa dym rozpędzony / ták <i>je</i> rozpędzaƺ : jáko śię woſk rozpływa od ogniá / <i>ták</i> niezbożnicy poginą przed oblicżem Bożym.
+Ale ſpráwiedliwi weſelić śię y rádowáć będą / przed oblicżem Bożym / y pląſáć będą od rádośći.
+Śpiewajćie Bogu / śpiewajćie Pſálmy Imienowi jego : gotujćie drogę temu / który jeźdźi ná obłokách : PAn jeſt Imię jego : Rádujćież śię przed oblicżem jego.
+Ojcem jeſt śirot / y ſędźią wdów : Bogiem w przybytku ſwym świętym.
+Bóg który ſámotne w <i>rodowite</i> domy rozmnaża : Wywodźi więźnie z oków : ále odporni mieƺkáć muƺą w źiemi ſuchey.
+Boże / gdyś wychodźił przed oblicżem ludu twego / gdyś chodźił po puƺcży : Selá :
+Ziemiá śię trzęſłá / tákże y niebioſá rozpływáły śię przed oblicżem Bożym : y tá górá Synáj <i>drżałá</i> przed twarzą Bogá / Bogá Izráelſkiego.
+Deƺcż obfity zpuƺcżałeś hojnie o Boże ná dźiedźictwo twoje : á gdy omdlewáło / tyś je záś otrzeźwiał.
+Zaſtępy twoje mieƺkáją w nim / <i>któreś ty</i> dla ubogiego nágotował dobrotą twoją o Boże!
+PAN dał ſłowo <i>ſwe, y</i> te / które poćiechy zwiáſtowáły / zaſtęp wielki mówiących.
+Królowie z wojſki ućiekáli / ućiekáli : ále tá która przyglądáłá domu / dźieliłá łupy.
+Choćiaśćie leżeć muśieli miedzy kotły / <i>przećię będźiećie</i> jáko gołębicá / májąca piórá pośrzebrzone / á którey ſkrzydłá jáko żółte złoto.
+Gdy Wƺechmogący rozproƺy Króle w tey źiemi / wybielejeƺ jáko śnieg ná <i>górze</i> Sálmon.
+Ná górze Bożey / ná górze Báſáńſkiey / ná górze págórcżyſtey / ná górze Báſáńſkiey.
+Przecżże wyſkákujećie góry págórcżyſte? ná teyći górze ulubił ſobie Bóg mieƺkánie : Támći PAN będźie mieƺkał ná wieki.
+Wozów Bożych <i>jeſt</i> dwádźieśćiá tyśięcy / wiele tyśięcy Anjołów : ále PAN miedzy nimi <i>jáko ná</i> Synáj w Świątnicey <i>przebywa</i>.
+Wſtąpiłeś ná wyſokość : wiodłeś pojimáne więźnie : nábrałeś dárów dla ludźi : y naodporniejƺe / PAnie Boże / przywiodłeś / áby mieƺkáli <i>z námi</i>.
+Błogoſłáwiony PAn : ná káżdy dźień hojnie nas opátruje <i>dobrámi ſwymi</i> ; Bóg zbáwienia náƺego : Selá.
+<i>On</i> jeſt Bóg náƺ / Bóg obfite° zbáwienia : Pánujący PAn z śmierći wywodźi.
+Zájiſte Bóg zráni głowę nieprzyjaćiół ſwojich / y wierzch głowy włoſámi nákryty chodzące w grzechách ſwojich.
+Rzekł Pan : Wyprowádzę záś <i>ſwoje</i> jáko z Báſán : wywiodę <i>je</i> záś z głębokośći morſkiey.
+Przetoż będźie nogá twojá zbrocżona we krwi / y język pſów twojich <i>we krwi</i> nieprzyjaćielſkiey.
+Widźieli ćiągnienia twoje Boże / ćiągnienia Bogá mego / y królá mego / w świątnicey.
+Wprzód ƺli śpiewacy / á zá nimi grájący ná inſtrumenćiech / á w pośrzodku Pánienki bijąc w bębny.
+W zgromádzeniách błogoſławćie Bogu : <i>błogoſławćie</i> PAnu / którzyśćie z narodu Izráelſkiego. Tu <i>niech będźie</i> Benjámin málucżki / który je opánował :
+Tu Kśiążętá Judſkie / y hufy ich : Kśiążętá Zábulońſkie / y Kśiążętá Neftálimſkie.
+Obdárzył ćię Bóg twój śiłą : Utwirdź o Boże to / coś w nas ſpráwił.
+Dla kośćiołá twego / <i>który jeſt</i> w Jeruzalem / będąć Królowie dáry przynośić.
+Poraź pocżet Kopijników / zgromádzenie mocnych wodzów / y ludu bujnego / hárde / chlubiące śię kęſem śrebrá : roſproƺ narody prágnące wojny.
+Przydąć zacne Kśiążętá z Egiptu : Murzyńſka źiemiá poſpieƺy śię wyćiągnąć ręce ſwe do Bogá.
+Króleſtwá źiemie / śpiewajćież Bogu śpiewajćie PAnu : Selá.
+Temu który jeźdźi ná nawyżƺych niebioſách od wiecżnośći : oto wydawa głos ſwój / głos mocy <i>ſwojey</i>.
+Przyznajćie moc Bogu : nád Izráelem doſtojność jego / á wielmożność jego ná obłokách.
+Stráƺnyś jeſt o Boże z świętych przybytków twojich : Bóg Izráelſki ſam dawa moc y śiły ludowi <i>ſwemu. Niechajże będźie</i> Bóg błogoſłáwiony.


### PR DESCRIPTION
w.27. wydanie z 1660 poprawia i daje kropkę po "Izráelſkiego" i tak zostawiłam
