### PR TITLE
Żyd.6,10.

### DIFF
--- a/2023/58-heb/06.txt
+++ b/2023/58-heb/06.txt
@@ -1,0 +1,20 @@
+
+
+
+
+
+
+
+
+
+Abowiem nie jeſt Bóg nieſpráwiedliwy / áby zápomniał prace wáƺey y prácowitey miłośći / którąśćie okazáli ku Imieniu jego ; gdyśćie ſłużyli świętym / y <i>jeƺcże</i> ſłużyćie.
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
zapamiętał -> zapomniał (KJV + TR)
"επιλαθεσθαι" - zapomnieć 

Możliwe że ogólna zasada jest taka, że w XVII / XIX wieku słowo "zapamiętać" znaczyło "zapomnieć" w języku polskim oraz rosyjskim; obecnie w języku rosyjskim panuje taka zasada.

W tym i nowszych Pull Requestach sprawdzono i zamieniono wszystkie wystąpienia w tekście "zapamiętać" (+ odmiany) na "zapomnieć".
Sprawdzono także wystąpienia: *pamię* zapomni* zapomin* przypomni* wspomni* - w przypadku tych wyrazów nie były wymagane zmiany.