### PR TITLE
Tren.2,6.

### DIFF
--- a/2023/25-lam/02.txt
+++ b/2023/25-lam/02.txt
@@ -1,0 +1,22 @@
+
+
+
+
+
+Oderwał mocą płot ſwój jáko od ogrodá : zepſował namiot ſwój : PAN przywiódł w zápomnienie w Syonie urocżyſte Świętá y Sábbáty : á odrzućił w gniewie popędliwośći ſwojey Królá y Kápłaná.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
zápámiętánie -> zápomnienie (KJV + TM)
hebr. "שכח" - zapomnieć

KJV 1611:
<img width="774" height="213" alt="Tren 2-1" src="https://github.com/user-attachments/assets/427194d8-5ce3-4802-83fc-5a6675d58721" />
<img width="774" height="259" alt="Tren 2-2" src="https://github.com/user-attachments/assets/01b70c55-71f2-4008-86cc-22ed970fa9f7" />
