### PR TITLE
2 Sam. 13.

### DIFF
--- a/1632/10-reg/13.txt
+++ b/1632/10-reg/13.txt
@@ -1,39 +1,39 @@
-Y ſtáło śię potem / że Abſálom / ſyn Dawidá / miał śioſtrę piękną / imieniem Támár / którey śię rozmiłował Amnon / ſyn Dawidá.
-Y trápił śię Amnon ták / że záchorował dla Támáry / śioſtry ſwojey ; bo pánną byłá / y trudno śię zdáło Amnonowi / áby jey co miał ucżynić.
-Lecż Amnon miał przyjáćielá / którego zwano Jonádáb / ſyn Semmy / brátá Dawidowego ; á ten Jonádáb był mężem bárzo mądrym.
-Który mu rzekł : Cżemuż ták ſchnieƺ / ſynu królewſki / ode dniá do dniá? cżemuż mi nie oznájmiƺ? Tedy mu rzekł Amnon : Rozmiłowáłem śię Támáry śioſtry Abſálomá / brátá mego.
-Y rzekł mu Jonádáb : Ukłádź śię ná łóżku twojim / á ucżyń śię chorym ; á gdy przydźie oćiec twój / áby ćię náwiedźił / rzecżeƺ mu : Niech przydźie proƺę Támár / śioſtrá mojá / y da mi jeść / á nágotuje przed ocżymá memi potráwę / ábym widźiał á jádł z ręki jey.
-Tedy śię ukłádł Amnon / zmyślájąc ſobie chorobę. A gdy przyƺedł król náwiedzáć go / rzekł Amnon do królá : Niech przydźie proƺę Támár / śioſtrá mojá / áby zgotowáłá przed ocżymá memi dwá plácki / ábym jádł z ręki jey.
-Przetoż poſłał Dawid do Támáry w dom / mówiąc : Idź záráz do domu Amnoná / brátá twego / á nágotuj mu potráwę.
-Przyƺłá tedy Támár do domu Amnoná / brátá ſwego / á on leżał ; á wźiąwƺy mąki rozmąćiłá / y ucżyniłá plácki przed ocżymá jego / y upiekłá je.
-Potem wźiąwƺy pánewkę / wyłożyłá przedeń ; ále niechćiał jeść. Y rzekł Amnon : Káżćie wyjść precż wƺyſtkim odemnie ; á ták wyƺli wƺyſcy od niego.
-Tedy rzekł Amnon do Támáry : Przynieś ſámá tę potráwę do pokoju / ábym jádł z ręki twej. A ták wźiąwƺy Támárá plácki / które nágotowáłá / przynioſłá je przed Amnoná / brátá ſwego / do pokoju.
-A gdy mu podáwáłá / áby jádł / uchwyćiwƺy ją / rzekł do niej : Pójdź / leż ze mną / śioſtro mojá.
-Która mu rzekłá : Zániecháj / bráćie mój / á nie cżyń mi gwáłtu / bo śię niemá dźiáć nic tákiego w Izráelu ; nie cżyńże tego ƺáleńſtwá.
-Bo gdźieżebym śię obróćiłá z zelżywośćią moją? á ty będźieƺ jáko jeden z ƺálonych w Izráelu. Ale rácżey mów proƺę z królem ; bo mię nie odmówi tobie.
-Lecż on nie chćiał uſłucháć głoſu jey / ále zmógƺy ją / ucżynił jey gwáłt / y leżał z nią.
-Potem nienáwidźiał jey Amnon nienáwiśćią bárzo wielką / ták iż więkƺá byłá nienáwiść / którą jey nienáwidźiał / niż miłość / którą ją pierwej miłował. Y rzekł jey Amnon : Wſtáń / idź precż.
-Która mu odpowiedźiáłá : Dla tego to więkƺá złość / niż owá / którąś zemną popełnił / że mię wygániáƺ. Ale jey on nie chćiał uſłucháć.
-Owƺem záwołáwƺy chłopcá ſwego / który mu poſługiwał / rzekł : Wywiedźćie tę záráz precż odemnie / á zámknij drzwi zá nią.
-( Ale oná miáłá ná ſobie pſtrą ſuknią ; ábowiem w tákowych ſukniách chádzáły córki królewſkie / pánny / ) y wywiódł ją precż ſługá jego / y záwárł drzwi zá nią.
-Tedy poſypáłá Támár popiołem głowę ſwą / á pſtrą ƺátę / która byłá ná niej / rozdárłá / y włożywƺy rękę ſwą ná głowę ſwoję / poƺłá / á idąc krzycżáłá.
-Y rzekł do niej Abſálom / brát jey : Albo Amnon / brát twój / był z tobą? Milcżże / śioſtro mojá ; brát twój jeſt / nie przypuƺcżáj tego do ſercá ſwego. A ták mieƺkáłá Támár będąc opuƺcżoná / w domu Abſálomá / brátá ſwego.
-A król Dawid uſłyƺáwƺy o tym wƺyſtkim / rozgniewał śię bárzo.
-Y nie mówił Abſálom z Amnonem áni źle áni dobrze ; bo nienáwidźiał Abſálom Amnoná / przeto że zgwáłćił Támárę / śioſtrę jego.
-Y ſtáło śię po wyśćiu dwu lat / gdy ſtrzyżono owce Abſálomowe w Báálcháſor / które jeſt w Efráim / że wezwał Abſálom wƺyſtkich ſynów królewſkich.
-Bo przyƺedł Abſálom do królá y rzekł : Oto teraz ſtrzygą owce ſłudze twemu ; niech idźie proƺę król y ſłudzy jego z ſługą twoim.
-Y rzekł król do Abſálomá : Nie / ſynu mój ; niech teraz nie chodźimy wƺyſcy / ábyſmy ćię nie obćiążyli. A choć mu przynáglał / nie chćiał iść / ále mu błogoſłáwił.
-Rzekł potem Abſálom : Ponieważ ty nie chceƺ / niechże idźie proƺę z námi Amnon / brát mój. Y rzekł mu król : A pocóżby miał iść z tobą?
-A gdy nań nálegał Abſálom / poſłał z nim Amnoná / y wƺyſtkie ſyny królewſkie.
-Tedy przykázał Abſálom ſługom ſwoim / mówiąc : Pilnujćie proƺę / gdy podweſeli ſerce ſwoje Amnon winem / á rzekę do was : Bijćie Amnoná / zábijćież go / nie bójćie śię / bom ja wam rozkázał ; zmocnijćież śię / á mężnie ſobie pocżnijćie.
-Y ucżynili ſłudzy Abſálomowi Amnonowi / jáko im był rozkázał Abſálom. Przetoż wſtáwƺy wƺyſcy ſynowie królewſcy / wśiedli káżdy ná mułá ſwego / y ućiekli.
-Wtem gdy jeƺcże byli w drodze / wieść przyƺłá do Dawidá w te ſłowá : Pozábijał Abſálom wƺyſtkie ſyny królewſkie / y nie zoſtał z nich áni jeden.
-Tedy wſtał król y rozdárł ƺáty ſwoje / y pádł ná źiemię / á wƺyſcy ſłudzy jego ſtáli około niego / rozdárƺy ƺáty ſwe.
-A ozwáwƺy śię Jonádáb / ſyn Semmy / brátá Dawidowego / rzekł : Niech nie mówi pán mój / że wƺyſtkie młodźieńce / ſyny królewſkie / pobito ; boć tylko ſám Amnon zábity / gdyż to w umyśle Abſálomowym ułożono było od onego dniá / którego zgwáłćił Támárę / śioſtrę jego.
-Przetoż teraz niech nie przypuƺcżá tego król / pán mój / do ſercá ſwego / mówiąc : Wƺyſcy ſynowie królewſcy polegli / gdyż tylko ſám Amnon poległ.
-Tedy ućiekł Abſálom ; á podnióſƺy ſługá / który był ná ſtráży / ocży ſwe / ujrzał / á oto / lud wielki przychodźił drogą / którą chodzono do niego z boku góry.
-Y rzekł Jonádáb do królá : Oto ſynowie królewſcy jádą ; wedle ſłowá ſługi twego ták śię ſtáło.
-A gdy przeſtał mówić / oto ſynowie królewſcy przyƺli / á podnióſƺy głoſy ſwe płákáli ; tákże y król / y wƺyſcy ſłudzy jego płákáli płácżem bárzo wielkim.
-Ale Abſálom ućiekƺy uƺedł do Tolmájá / ſyná Ammihudowego / królá Gieſſur ; y żáłował Dawid ſyná ſwego po one wƺyſtkie dni.
-A Abſálom ućiekł / y przyƺedł do Gieſſur / á był tám przez trzy látá.
-Potem prágnął król Dawid widźieć Abſálomá ; bo już był odżáłował śmierći Amnonowej.
+Y ſtáło śię potym / że Abſálom Syn Dawidów miał śioſtrę piękną / imieniem Támár : którey śię rozmiłował Amnon Syn Dawidów.
+Y trapił śię Amnon ták / że záchorzał dla Támáry Śioſtry ſwojey. Bo Pánną byłá : Y trudno śię zdáło Amnonowi áby jey co miał ucżynić.
+Lecż Amnon miał przyjaćielá / którego zwano Jonádáb / Syn Semmy brátá Dawidowego : ( á ten Jonádáb był mężem bárzo mądrym ).
+Który mu rzekł : Cżemuż ták ſchnieƺ Synu królewſki ode dniá do dniá? cżemuż mi nieoznájmiƺ? Tedy mu rzekł Amnon : Rozmiłowałem śię Támáry / Śioſtry Abſálomá brátá mego.
+Y rzekł mu Jonádáb : Ukłádź śię ná łóżku twojim / á ucżyń śię chorym / á gdy przydźie Oćiec twój áby ćię náwiedźił / rzecżeƺ mu : Niech przydźie proƺę / Támár śioſtrá mojá / y da mi jeść / á nágotuje przed ocżymá mymi potráwę / ábym widźiał á jadł z ręku jey.
+Tedy śię układł Amnon / zmyślájąc ſobie chorobę : á gdy przyƺedł Król náwiedzáć go / rzekł Amnon do Królá : Niech przydźie / proƺę / Támár śioſtrá mojá / áby zgotowáłá przed ocżymá mymi dwá plácki / ábym jadł z ręku jey.
+Przetoż poſłał Dawid do Támáry w dom / mówiąc : Idź záraz do domu Amnoná brátá twego / á nágotuj mu potráwę.
+Przyƺłá tedy Támár do domu Amnoná brátá ſwego / á on leżał : á wźiąwƺy mąki rozmąćiłá / y ucżyniłá plácki przed ocżymá jego / y upiekłá je.
+Potym wźiąwƺy panewkę wyłożyłá przedeń : ále niechćiał jeść. Y rzekł Amnon : Każćie precż wyjść wƺyſtkim ode mnie : á ták wyƺli wƺyſcy od niego.
+Tedy rzekł Amnon do Támáry : Przynieś ſámá tę potráwę do pokoju / ábym jadł z ręki twey : A ták wźiąwƺy Támárá plácki / które nágotowáłá / przynioſłá je przed Amnoná brátá ſwego do pokoju.
+A gdy mu podawáłá / áby jadł / uchwyćiwƺy ją rzekł do niey : Pódź / leż ze mną śioſtro mojá.
+Która mu rzekłá / Zániechaj Bráćie mój / á niecżyń mi gwałtu : bo śię niema dźiać <i>nic</i> tákiego w Izráelu : niecżyńże tego ƺaleńſtwá.
+Bo gdźieżebym śię obróćiłá z zelżywośćią moją? á ty będźieƺ jáko jeden z ƺalonych w Izráelu : ále rácżey mów proƺę z Królem / bo mię nie odmówi tobie.
+Lecż on niechćiał uſłucháć głoſu jey / ále zmógƺy ją / ucżynił jey gwałt / y leżał z nią.
+Potym nienawidźiał jey Amnon nienawiśćią bárzo wielką : ták yż więkƺa byłá nienawiść / którą jey nienawidźiał / niż miłość którą ją <i>pierwey</i> miłował : Y rzekł jey Amnon : Wſtań / idź precż.
+Która mu odpowiedźiáłá : Dla tego to więkƺa złość / niż owa którąś zemną popełnił / że mię wyganiaƺ : Ale jey on nie chćiał uſłucháć.
+Owƺem záwoławƺy chłopcá ſwego / który mu poſługował / rzekł : Wywiedźćie tę záraz precż ode mnie / á zámkni drzwi zá nią.
+( Ale oná miáłá ná ſobie pſtrą ſuknią : ábowiem w tákowych ſukniách chadzáły córki królewſkie / pánny / ) y wywiódł ją precż ſługá jego / y zápárł drzwi zá nią.
+Tedy poſypáłá Támár popiołem głowę ſwą / á pſtrą ƺátę która <i>byłá</i> ná niey / rozdárłá : y włożywƺy rękę ſwą ná głowę ſwoję / poƺłá / á idąc krzycżáłá.
+Y rzekł do niey Abſálom brát jey : Albo Amnon brát twój był z tobą? Milcżże śioſtro mojá / brát twój jeſt : nie przypuƺcżaj tego do ſercá ſwego. A ták mieƺkáłá Támár <i>będąc</i> opuƺcżona w domu Abſálomá brátá ſwego.
+A Król Dawid uſłyƺawƺy o tym wƺyſtkim / rozgniewał śię bárzo.
+Y nie mówił Abſálom z Amnonem / áni źle áni dobrze : Bo nienawidźiał Abſálom Amnoná / przeto że zgwałćił Támárę śioſtrę jego.
+Y ſtáło śię po wyśćiu dwu lat / gdy ſtrzyżono <i>owce</i> Abſálomowe w Báálcháſor / które jeſt w Efráim : że wezwał Abſálom wƺyſtkich Synów królewſkich.
+Bo przyƺedł Abſálom do Królá y rzekł : Oto teraz ſtrzygą <i>owce</i> ſłudze twemu / niech idźie proƺę Król / y ſłudzy jego z ſługą twojim.
+Y rzekł Król do Abſálomá : Nie / Synu mój : niech teraz niechodźiemy wƺyſcy / ábyſmy ćię nie obćiążyli : A choć mu przynaglał / niechćiał iść : ále mu błogoſłáwił.
+Rzekł potym Abſálom : Ponieważ <i>ty</i> niechceƺ / niechże idźie proƺę z námi Amnon brát mój : Y rzekł mu Król : A pocóżby miał iść z tobą?
+A gdy nań nálegał Abſálom / poſłał z nim Amnoná / y wƺyſtkie Syny królewſkie.
+Tedy przykazał Abſálom ſługom ſwojim / mówiąc : Pilnujćie proƺę gdy podweſeli ſerce ſwoje Amnon winem / á rzekę do was / bijćie Amnoná / zábijćież go / nie bójćie śię / bom ja wam rozkazał : zmocnićież śię / á mężnie ſobie pocżnićie.
+Y ucżynili ſłudzy Abſálomowi Amnonowi / jáko im był rozkazał Abſálom : Przetoż wſtawƺy wƺyſcy Synowie królewſcy / wśiedli káżdy ná mułá ſwego / y ućiekli.
+Wtym gdy jeƺcże byli w drodze / wieść przyƺłá do Dawidá / w te ſłowá ; Pozábijał Abſálom wƺyſtkie Syny królewſkie / y nie zoſtał z nich áni jeden.
+Tedy wſtał Król / y rozdárł ƺáty ſwoje / y padł ná źiemię : á wƺyſcy ſłudzy jego / ſtáli około niego / rozdárƺy ƺáty ſwe.
+A ozwawƺy śię Jonádáb / Syn Semmy brátá Dawidowego / rzekł ; Niech nie mówi Pán mój / <i>że</i> wƺyſtkie młodźieńce / Syny królewſkie / pobito : boć tylko ſam Amnon zábit ; Gdyż to w umyśle Abſálomowym ułożono było / od onego dniá / którego zgwałćił Támárę śioſtrę jego.
+Przetoż teraz niech nie przypuƺcża tego Król Pán mój do ſercá ſwego / mówiąc ; wƺyſcy Synowie królewſcy polegli : gdyż <i>tylko</i> ſam Amnon poległ.
+Tedy ućiekł Abſálom : á podnióżƺy ſługá który był ná ſtraży ocży ſwe / ujrzał / á oto lud wielki przychodźił drogą / którą chodzono do niego z boku góry :
+Y rzekł Jonádáb do Królá : Owo Synowie królewſcy jádą : wedle ſłowá ſługi twego / ták śię ſtáło.
+A gdy przeſtał mówić / oto Synowie królewſcy przyƺli / á podnióżƺy głoſy ſwe / płákáli : tákże y Król / y wƺyſcy ſłudzy jego / płákáli płácżem bárzo wielkim.
+Ale Abſálom ućiekƺy / uƺedł do Tolmájá / Syná Ammihudowego / królá Geſſur : y żáłował <i>Dawid</i> Syná ſwego po one wƺyſtkie dni.
+A Abſálom ućiekł / y przyƺedł do Geſſur : á był tám przez trzy látá.
+Potym prágnął Król Dawid widźieć Abſálomá / bo już był odżáłował śmierći Amnonowey.

--- a/1632/10-reg/13.txt
+++ b/1632/10-reg/13.txt
@@ -6,7 +6,7 @@ Y rzekł mu Jonádáb : Ukłádź śię ná łóżku twojim / á ucżyń śię c
 Tedy śię układł Amnon / zmyślájąc ſobie chorobę : á gdy przyƺedł Król náwiedzáć go / rzekł Amnon do Królá : Niech przydźie / proƺę / Támár śioſtrá mojá / áby zgotowáłá przed ocżymá mymi dwá plácki / ábym jadł z ręku jey.
 Przetoż poſłał Dawid do Támáry w dom / mówiąc : Idź záraz do domu Amnoná brátá twego / á nágotuj mu potráwę.
 Przyƺłá tedy Támár do domu Amnoná brátá ſwego / á on leżał : á wźiąwƺy mąki rozmąćiłá / y ucżyniłá plácki przed ocżymá jego / y upiekłá je.
-Potym wźiąwƺy panewkę wyłożyłá przedeń : ále niechćiał jeść. Y rzekł Amnon : Każćie precż wyjść wƺyſtkim ode mnie : á ták wyƺli wƺyſcy od niego.
+Potym wźiąwƺy panewkę wyłożyłá przedeń : ále niechćiał jeść. Y rzekł Amnon : Każćie precż wƺyſtkim ode mnie : á ták wyƺli wƺyſcy od niego.
 Tedy rzekł Amnon do Támáry : Przynieś ſámá tę potráwę do pokoju / ábym jadł z ręki twey : A ták wźiąwƺy Támárá plácki / które nágotowáłá / przynioſłá je przed Amnoná brátá ſwego do pokoju.
 A gdy mu podawáłá / áby jadł / uchwyćiwƺy ją rzekł do niey : Pódź / leż ze mną śioſtro mojá.
 Która mu rzekłá / Zániechaj Bráćie mój / á niecżyń mi gwałtu : bo śię niema dźiać <i>nic</i> tákiego w Izráelu : niecżyńże tego ƺaleńſtwá.


### PR DESCRIPTION
w. 9 - mimo braku "wyjść" w źródle BG, pozostawiono ze względu na oryginał, gdzie występuje.