### PR TITLE
Dzie.3,6.

### DIFF
--- a/1632/44-act/03.txt
+++ b/1632/44-act/03.txt
@@ -3,7 +3,7 @@ A mąż niektóry będąc chromy / záraz z żywotá mátki ſwojey był noƺony
 Ten ujrzawƺy Piotrá y Janá / że mieli wniść do Kośćiołá / prośił <i>ich</i> o jáłmużnę.
 A Piotr z Janem pilnie nań pátrząc / rzekli : Wejrzy ná nas :
 Tedy on z pilnośćią pátrzał ná nie / ſpodźiewájąc śię co wźiąć od nich.
-Y rzekł Piotr : Srebrá y złotá nie mam ; lecż co mam toć dawam : w Imieniu JEzuſá CHryſtuſá Názáreńſkiego / wſtań á chodź.
+Y rzekł Piotr : Śrebrá y złotá nie mam ; lecż co mam toć dawam : w Imieniu JEzuſá CHryſtuſá Názáreńſkiego / wſtań á chodź.
 A ująwƺy go zá práwą rękę jego / podnióſł go : á zárázem utwirdzone były nogi jego / y koſtki.
 Y wyſkocżywƺy / ſtánął y chodźił : á wƺedł z nimi do Kośćiołá / chodząc y ſkacżąc á chwaląc Bogá.
 A widźiał go wƺyſtek lud chodzącego y chwalącego Bogá.
@@ -24,3 +24,4 @@ Y ſtánie śię / <i>że</i> káżda duƺá / któraby nie ſłucháłá tego P
 Aleć y wƺyſcy Prorocy od Sámuelá / y od innych po nim / ile ich kolwiek mówiło / przepowiádáli też te dni.
 Wyśćie ſynámi Prorockimi / y przymierza które poſtánowił Bóg z Ojcy náƺymi / mówiąc do Abráhámá ; A w náśieniu twojim błogoſłáwione będą wƺyſtkie narody źiemie.
 Wamći naprzód BÓG / wzbudźiwƺy Syná ſwego JEzuſá / poſłał go / áby wam błogoſłáwił ; żeby śię káżdy z was odwróćił od złośći ſwojich.
+


### PR DESCRIPTION
Niektóre wyrazy w ortografii 17-wiecznej mają pisownię z polskim znakiem specjalnym np. "śrebro". Zasadą w pisowni z 17 wieku jest że litery drukowane pomijają polskie znaki specjalne. Żeby jednak zachować pisownię z 17 wieku należy zamienić "Srebro" -> "Śrebro". Najlepiej od razu jedną komendą zamienić wszystkie wystąpienia tego wyrazu z dużej litery na wersję z "Ś".