### PR TITLE
1 Król. 5.

### DIFF
--- a/1632/11-reg/05.txt
+++ b/1632/11-reg/05.txt
@@ -1,18 +1,18 @@
-Y poſłał Hirám / król Tyrſki / ſługi ſwe do Sálomoná / bo uſłyƺał / że go pomázáno zá królá miáſto ojcá jego ; ábowiem miłował Hirám Dawidá po wƺyſtkie dni.
-Sálomon też záś poſłał do Hirámá / mówiąc :
-Ty wieƺ / że Dawid / oćiec mój / nie mógł budowáć domu imieniowi Páná / Bogá ſwego / dla wojen / które go były ogárnęły / áż nieprzyjáćioły podał Pán pod ſtopy nóg jego ;
-Ale teraz Pán / Bóg mój / dał mi odpocżynienie zewƺąd / y niemám żádnego przećiwniká / áni zábiegu złego.
-A otom umyślił budowáć dom imieniowi Páná / Bogá mego / jáko powiedźiał Pán do Dawidá / ojcá mego / mówiąc : Syn twój / któremu dam miáſto ćiebie ośiąść ſtolicę twoję / ten zbuduje dom ten imieniowi memu.
-Przetoż teraz rozkáż / áby mi nárąbáno ceder ná Libánie / á ſłudzy moi będą z ſługámi twoimi / á zápłátę ſług twojich dam tobie ták / jáko rzecżeƺ ; ábowiem ty wieƺ / że niemáƺ miedzy námi mężá / któryby umiał ták rąbáć drzewo / jáko Sydońcżycy.
-A gdy uſłyƺał Hirám ſłowá Sálomonowe / urádował śię bárzo y rzekł : Błogoſłáwiony Pán dźiśiáj / który dał Dawidowi ſyná mądrego nád tym ludem wielkim.
-Y poſłał Hirám do Sálomoná / mówiąc : Słyƺáłem z cżemeś poſłał do mnie. Ucżynię wƺyſtkę wolą twoję około drzewá cedrowego / y około drzewá jodłowego.
-Słudzy moi zwiozą je z Libánu do morzá / á ja je káżę złożyć w trátwy / y ſpuśćić morzem áż do miejſcá / o którem mi dáƺ znáć / y tám je rozwiążę / á ty je pobierzeƺ. Ty też ucżyniƺ wolą moję / á dáƺ obrok cżeládźi mojey.
-A ták Hirám dodáwał Sálomonowi drzewá cedrowego / y drzewá jodłowego / jáko wiele chćiał.
-Sálomon tákże dáwał Hirámowi dwádźieśćiá tyśięcy miár pƺenicy ná żywność cżeládźi jego / y dwádźieśćiá tyśięcy miár oliwy wybijáney ; to dáwał Sálomon Hirámowi ná káżdy rok.
-A Pán dał mądrość Sálomonowi / jáko mu był obiecał / y był pokój miedzy Hirámem y miedzy Sálomonem / á ucżynili przymierze miedzy ſobą.
-Tedy kázał wybieráć król Sálomon robotniki ze wƺyſtkiego Izráelá / á było wybránych trzydźieśći tyśięcy mężów.
-Które ſłał do Libánu po dźieśięć tyśięcy ná káżdy mieśiąc / ná przemiány ; po mieśiącu mieƺkáli ná Libánie / á po dwá mieśiące w domu ſwym ; á Adonirám był przełożony nád tymi wybránymi.
-Miał też Sálomon śiedmdźieśiąt tyśięcy tych / którzy nośili ćiężáry / á ośmdźieśiąt tyśięcy tych / którzy rąbáli ná górze ;
-Oprócż przedniejƺych urzędników Sálomonowych / których było nád robotą trzy tyśiące y trzy ſtá / którzy byli przełożeni nád ludem odpráwującym robotę.
-Rozkázał też król / áby wożono kámienie wielkie / kámienie drogie / y kámienie ćioſáne / ná záłożenie gruntów domu.
-Cioſáli tedy rzemieślnicy Sálomonowi / y rzemieślnicy Hirámowi / y Gimblimcżycy. A ták gotowáli drzewo y kámienie ná budowánie domu.
+Y poſłał Hirám Król Tyrſki ſługi ſwe do Sálomoná : bo uſłyƺał że go pomázano zá Królá / miáſto Ojcá jego : ábowiem miłował Hirám Dawidá po wƺyſtkie dni.
+Sálomon <i>też</i> záś poſłał do Hirámá / mówiąc :
+Ty wieƺ że Dawid Oćiec mój nie mógł budowáć domu Imieniowi PANA Bogá ſwego dla wojen które go były ogárnęły / áż nieprzyjaćioły podał PAN pod ſtopy nóg jego :
+Ale teraz PAN Bóg mój dał mi odpocżynienie zewƺąd / <i>y</i> nie mam żadnego przećiwniká / áni zabiegu złego.
+A otom umyślił budowáć dom Imieniowi PANA Bogá mego / jáko powiedźiał PAN do Dawidá Ojcá mego / mówiąc : Syn twój / któremu dam miáſto ćiebie ośieść ſtolicę twoję / ten zbuduje dom ten Imieniowi memu.
+Przetoż teraz rozkaż áby mi nárąbano Cedrów ná Libánie / á ſłudzy moji będą z ſługámi twojimi : á zapłátę ſług twojich dam tobie ták jáko rzecżeƺ : ábowiem ty wieƺ / że niemáƺ miedzy námi mężá któryby umiał <i>ták</i> rąbáć drzewo / jáko Sydońcżycy.
+A gdy uſłyƺał Hirám ſłowá Sálomonowe / urádował śię bárzo / y rzekł ; Błogoſłáwiony PAN dźiśia / który dał Dawidowi Syná mądrego / nád tym ludem wielkim.
+Y poſłał Hirám do Sálomoná / mówiąc ; Słyƺałem z cżymeś poſłał do mnie : Ucżynię wƺyſtkę wolą twoję około drzewá Cedrowego / y około drzewá jodłowego.
+Słudzy moji zwiozą <i>je</i> z Libánu do morzá / á ja je każę złożyć w tráffty / <i>y ſpuśćić</i> morzem / áż do miejſcá o którym mi daƺ znáć / y tám je rozwiążę / á ty je pobierzeƺ : Ty też ucżyniƺ wolą moję / á daƺ obrok cżeládźi mojey.
+A ták Hirám dodawał Sálomonowi drzewá Cedrowego / y drzewá jodłowego jáko wiele chćiał.
+Sálomon tákże dawał Hirámowi dwádźieśćiá tyśięcy miar pƺenice / ná żywność cżeládźi jego / y dwádźieśćiá tyśięcy miar oliwy wybijáney : To dawał Sálomon Hirámowi ná káżdy rok.
+A PAN dał mądrość Sálomonowi / jáko mu był obiecał : y był pokój miedzy Hirámem y miedzy Sálomonem / á ucżynili przymierze miedzy ſobą.
+Tedy kazał wybieráć Król Sálomon robotniki ze wƺyſtkiego Izráelá / á było wybránych trzydźieśći tyśięcy mężów.
+Które ſłał do Libánu po dźieśiąći tyśięcy ná káżdy mieśiąc / ná przemiány : po mieśiącu mieƺkáli ná Libánie / <i>á</i> po dwu mieśiącách w domu ſwym. A Adonirám był przełożony nád tymi wybránymi.
+Miał też Sálomon śiedmdźieśiąt tyśięcy tych / którzy nośili ćiężáry : á ośmdźieśiąt tyśięcy tych / którzy rąbáli ná górze.
+Oprócż przedniejƺych urzędników Sálomonowych / których <i>było</i> nád robotą trzy tyśiące / y trzy ſtá / którzy byli przełożeni nád ludem odpráwującym robotę.
+Rozkazał też Król / áby wożono kámienie wielkie / kámienie drogie / y kámienie ćioſáne / ná záłożenie gruntów domu.
+Cioſáli tedy rzemieślnicy Sálomonowi / y rzemieślnicy Hirámowi / y Gyblimcżycy : A ták gotowáli drzewo / y kámienie ná budowánie domu.


### PR DESCRIPTION
w. 5,11: usunięto kursywę przy "tysięcy" wg tekstu źródłowego.