### PR TITLE
Jak.2,26.

### DIFF
--- a/2023/59-jac/02.txt
+++ b/2023/59-jac/02.txt
@@ -23,4 +23,5 @@
 
 
 
-Abowiem jáko ćiáło bez Duchá jeſt martwe, ták y wiárá bez ucżynkow martwa jeſt.
+Abowiem jáko ćiáło bez Duchá jeſt martwe, ták y wiárá bez ucżynków martwa jeſt.
+

--- a/2023/59-jac/02.txt
+++ b/2023/59-jac/02.txt
@@ -24,4 +24,3 @@
 
 
 Abowiem jáko ćiáło bez Duchá jeſt martwe, ták y wiárá bez ucżynków martwa jeſt.
-


### PR DESCRIPTION
Proponuję też zamianę "Duchá" -> "duchá". Pisownia z dużej litery z tego co widzę jest charakterystyczna tylko dla wydania z 1606 (zarówno 1632, jak i 1660, 1879 i KJV mają pisownię z małej litery - dla np. fragmentu 1 Jan.4.1-3.; a KJV dla Jak.2,26.). Po zmianie na małą literę byłaby spójność z KJV i 1632 (wcześniej w 1632 "dusze" było również pisane z małej litery).