### PR TITLE
Ezech.1.

### DIFF
--- a/1632/26-eze/01.txt
+++ b/1632/26-eze/01.txt
@@ -1,28 +1,28 @@
-Y ſtáło śię trzydźieſtego roku / mieśiącá cżwártego / piątego dniá tegoż mieśiącá / gdym był w pośrzodku pojmánych u rzeki Chebár / że śię otworzyły niebioſá / y widźiałem widzenie Boże.
-Piątego dniá tegoż mieśiącá / ( ten jeſt rok piąty po záprowádzeniu królá Joáchyná. )
-Práwdźiwie ſtáło śię ſłowo Páńſkie do Ezechyjelá kápłáná / ſyná Buzowego / w źiemi Cháldejſkiej u rzeki Chebár / á byłá nád nim ręká Páńſka.
-Y widźiałem / á oto wiátr gwáłtowny przychodźił od północy / y obłok wielki / y ogień páłájący / á bláſk był około niego / á z pośrzodku jego wynikáłá jákoby niejáká prędká świátłość / z pośrzodku / mówię / onego ogniá.
-Tákże z pośrzodku jego ukázáło śię podobieńſtwo cżworgá zwierząt / których tákowy był kƺtáłt : Podobieńſtwo cżłowieká miáły /
-A káżde po cżtery twárze / tákże po cżtery ſkrzydłá káżde z nich miáło ;
-Nogi ich były nogi proſte / á ſtopá nóg ich jáko ſtopá nogi ćielęcey / á lśniáły śię włáśnie jáko miedź wypolerowáná ;
-Ręce ludzkie były pod ſkrzydłámi ich po cżterech ſtronách ich / á twárze ich y ſkrzydłá ich ná cżterech onych ſtronách ;
-Skrzydłá ich ſpojone były jedno z drugiem / nie obrácáły śię / gdy chodźiły / ále káżde w proſt ná ſwą ſtronę chodźiło.
-A podobieńſtwo twárzy ich tákie : Z przodku twárz ludzká á twárz lwiá po práwej ſtronie káżdego z nich / á twárz wołowá po lewej ſtronie wƺyſtkich cżworgá / tákże twárz orlą z tyłu miáło wƺyſtko cżworo z nich :
-A twárze ich y ſkrzydłá ich były podnieśione ku górze ; káżde zwierzę dwá ſkrzydłá ſpájáło z dwomá ſkrzydłámi drugiego / á dwomá przykrywáły ćiáło ſwoje ;
-A káżde z nich wproſt ná ſwą ſtronę chodźiło ; kędykolwiek duch chćiał / áby ƺły / tám ƺły / nie obrácáły śię / gdy chodźiły.
-Tákże podobieńſtwo onych zwierząt ná wejrzeniu było jáko węgle w ogniu rozpálone / pálące śię jáko pochodnie ; ten ogień uſtáwicżnie chodźił miedzy zwierzętámi / á on ogień miał bláſk / z którego ogniá wychodźiłá błyſkáwicá.
-Biegáły też one zwierzętá / y wrácáły śię jáko prędkie błyſkáwice.
-A gdym śię przypátrywał onym zwierzętom / á oto koło jedno było ná źiemi przy zwierzętách u cżterech twárzy káżdego z nich ;
-Ná wejrzeniu były kołá / y robotá ich jáko bárwá kámieniá Tárſys / á podobieńſtwo było jednákie onych cżterech kół / á były ná wejrzeniu y robotá ich / jákoby było koło w pośrzodku kołá ;
-Májąc iść ná cżtery ſtrony ſwoje chodźiły / á nie obrácáły śię / gdy chodźiły.
-Dzwoná táką wyſokość miáły / áż ſtrách z nich pochodźił ; te dzwoná w około wƺyſtkich cżterech kół pełne były ocżów.
-A gdy chodźiły zwierzętá / kołá też chodźiły podle nich ; á gdy śię podnośiły zwierzętá w górę od źiemi / podnośiły śię y kołá.
-Gdźiekolwiek chćiał duch / áby ƺły / tám ƺły : gdźie mówię duch chćiał / áby ƺły ; á kołá podnośiły śię przed niemi / bo duch zwierząt był w kołách.
-Gdy one ƺły / ƺły y kołá / á gdy one ſtáły / ſtáły ; á gdy śię podnośiły od źiemi / podnośiły śię też kołá z niemi ; bo duch zwierząt był w kołách.
-Nád głowámi zwierząt było podobieńſtwo rozpoſtárćiá jáko podobieńſtwo kryƺtáłu przezrocżyſtego rozćiągnionego nád głowámi ich z wierzchu ;
-A pod onem rozpoſtárćiem ſkrzydłá ich były podnieśione / jedno z drugiem ſpojone ; káżde miáło dwá / któremi śię przykrywáło / káżde / mówię / miáło dwá / któremi przykrywáło ćiáło ſwoje.
-Y ſłyƺáłem ƺum ſkrzydeł ich / jáko ƺum wód wielkich / jáko ƺum Wƺechmocnego / gdy chodźiły / y ƺum huku jáko ƺum wojſká ; á gdy ſtáły / ſpuśćiły ſkrzydłá ſwoje.
-A gdy ſtáły y ſpuƺcżáły ſkrzydłá ſwoje / tedy był ƺum z wierzchu nád rozpoſtárćiem / które było nád głową ich.
-A z wierzchu ná rozpoſtárćiu / które było nád głową ich / było podobieńſtwo ſtolicy ná wejrzeniu jáko kámień ƺáfirowy / á nád podobieńſtwem ſtolicy / ná nim z wierzchu ná wejrzeniu jáko oſobá cżłowieká.
-Y widźiałem ná wejrzeniu jákoby prędką świátłość / á wewnątrz w niej w około ná wejrzeniu jáko ogień od biódr jego w górę ; tákże też od biódr jego ná dół widźiałem ná wejrzeniu jáko ogień / y bláſk około niego.
-Jáká bywa tęcżá ná wejrzeniu / która bywa ná obłoku cżáſu deƺcżu / táki był ná wejrzeniu bláſk w około. Toć było widzenie podobieńſtwá chwały Páńſkiej / które gdym widźiał / upádłem ná oblicże ſwoje / y uſłyƺáłem głos mówiącego.
+Y ſtáło śię trzydźieſtego roku / <i>mieśiącá</i> cżwartego / piątego <i>dniá</i> tegoż mieśiącá / gdym był w pośrzodku pojimánych u rzeki Chebár / że śię otworzyły niebioſá / y widźiałem widzenia Boże.
+Piątego <i>dniá</i> tegoż mieśiącá : ( ten <i>jeſt</i> rok piąty / po záprowádzeniu Królá Joáchiná. )
+Prawdźiwie ſtáło śię ſłowo PAńſkie do Ezechielá Kápłaná / ſyná Buzowego / w źiemi Cháldejſkiey / u rzeki Chebár / á byłá nád nim ręká PAńſka.
+Y widźiałem / á oto wiátr gwałtowny przychodźił od Północy / <i>y</i> obłok wielki / y ogień pałájący / á bláſk był około niego : á z pośrzodku jego <i>wynikáłá</i> jákoby niejáka prętka świátłość ; z pośrzodku <i>mówię</i> onego ogniá.
+Tákże z pośrzodku jego <i>ukazało śię</i> podobieńſtwo cżworgá zwierząt : których tákowy był kƺtałt : Podobieńſtwo cżłowieká miáły.
+A káżde po cżterech twarzách / tákże po cżterech ſkrzydłách káżde z nich miáło.
+Nogi jich / były nogi proſte : á ſtopá nóg ich / jáko ſtopá nogi ćielęcey : á łſniáły śię / właśnie jáko miedź wypolerowána.
+Ręce ludzkie <i>były</i> pod ſkrzydłámi ich / po cżterech ſtronách ich : á  twarzy ich / y ſkrzydłá ich ná cżterech onych <i>ſtronách</i>.
+Skrzydłá ich ſpojone były jedno z drugim : nie obracáły śię gdy chodźiły / ále káżde w proſt ná ſwą ſtronę chodźiło.
+A podobieńſtwo twarzy ich <i>tákie : Z przodku</i> twarz ludzka / á twarz lwia po práwey ſtronie káżdego z nich : á twarz wołowa po lewey ſtronie wƺyſtkich cżworgá : tákże twarz orlą <i>z tyłu</i> miáło wƺyſtko cżworo z nich.
+A twarzy ich y ſkrzydłá ich <i>były</i> podnieśione ku górze : káżde <i>zwierzę</i> dwie <i>ſkrzydłá</i> ſpajáło <i>ze dwiemá ſkrzydłámi</i> drugiego / á dwiemá przykrywáły ćiáło ſwoje.
+A káżde z nich w proſt ná ſwą ſtronę chodźiło : kędykolwiek duch chćiał áby ƺły / tám ƺły : nie obracáły śię gdy chodźiły.
+Tákże podobieńſtwo onych zwierząt ná wejrzeniu było jáko węgle w ogniu rozpalone / palące śię jáko pochodnie : Ten <i>ogień</i> uſtáwicżnie chodźił miedzy zwierzętámi / á on ogień miał bláſk / z którego ogniá wychodźiłá błyſkáwicá.
+Biegáły też one zwierzętá / y wracáły śię jáko prętkie błyſkáwice.
+A gdym śię przypátrował onym zwierzętom : á oto koło jedno było ná źiemi przy zwierzętách / u cżterech twarzy káżdego z nich.
+Ná wejrzeniu były kołá / y robotá ich jáko bárwá <i>kámienia</i> Tárſys / á podobieńſtwo <i>było</i> jednákie onych cżterech <i>kół</i> : á były ná wejrzeniu y robotá ich / jákoby było koło w pośrzodku kołá.
+Májąc iść / ná cżterey ſtrony ſwoje chodźiły / á nie obracáły śię gdy chodźiły.
+Dzwoná táką wyſokość <i>miały,</i> áż ſtrách z nich pochodźił ; te dzwoná / w około wƺyſtkich cżterech <i>kół,</i> pełne były ocżu.
+A gdy chodźiły zwierzętá / kołá też chodźiły podle nich : á gdy śię podnośiły zwierzętá wzgórę od źiemie / podnośiły śię <i>y</i> kołá.
+Gdźiekolwiek chćiał duch áby ƺły / tám ƺły ; gdźie mówię <i>duch</i> chćiał áby ƺły : á kołá podnośiły śię przed nimi / bo duch zwierząt był w kołách.
+Gdy one ƺły / ƺły <i>y kołá</i> ; á gdy one ſtały / ſtały : á gdy śię podnośiły od źiemie / podnośiły śię też kołá z nimi : bo duch zwierząt był w kołách.
+Nád głowámi zwierząt / <i>było</i> podobieńſtwo rozpoſtárćia / jáko podobieńſtwo krzyƺtału przeźrocżyſtego / rozćiągnionego nád głowámi ich z wierzchu.
+A pod onym rozpoſtárćiem ſkrzydłá ich <i>były</i> podnieśione / jedno z drugim <i>ſpojone</i> : káżde <i>miáło</i> dwie / którymi śię przykrywáło : káżde mówię <i>miało</i> dwie / którymi przykrywáło ćiáło ſwoje.
+Y ſłyƺałem ƺum ſkrzydeł ich / jáko ƺum wód wielkich / jáko ƺum Wƺechmocnego / gdy chodźiły / <i>y</i> ƺum huku jáko ƺum wojſká : <i>á gdy</i> ſtały / ſpuśćiły ſkrzydłá ſwoje.
+A gdy ſtały <i>y</i> ſpuƺcżáły ſkrzydłá ſwoje / tedy był ƺum z wierzchu nád rozpoſtárćiem / które <i>było</i> nád głową ich.
+A z wierzchu ná rozpoſtárćiu / które <i>było</i> nád głową ich / było podobieńſtwo ſtolice / ná wejrzeniu jáko kámień Száfirowy : á nád podobieńſtwem ſtolice / ná nim z wierzchu ná wejrzeniu jáko oſobá cżłowieká.
+Y widźiałem ná wejrzeniu jákoby prętką świátłość : <i>á</i> wewnątrz w niey w około ná wejrzeniu jáko ogień / od biódr jego wzgórę : tákże też od biódr jego ná dół widźiałem ná wejrzeniu jáko ogień / y bláſk około niego.
+Jáka bywa tęcża ná wejrzeniu / która bywa ná obłoku cżáſu deƺcżu / táki był ná wejrzeniu bláſk w około. Toć <i>było</i> widzenie podobieńſtwá chwały PAńſkiey : <i>które</i> gdym widźiał / upadłem ná oblicże ſwoje / y uſłyƺałem głos mówiące°.


### PR DESCRIPTION
w.8. literówka "cżterzech", zostawiłem "cżterech", bo taka pisownia jest też w Ezech.43,16-17.
w.22. zostawiłem tak jak w 1660 "krzyƺtału"
w.28. zostawiłem tak jak w 1660 "." zamiast ":" na końcu wersetu