### PR TITLE
Ezech.3,1-3;21.

### DIFF
--- a/2023/26-eze/03.txt
+++ b/2023/26-eze/03.txt
@@ -25,4 +25,3 @@ Ale jeſlibyś ty nápomniał ſpráwiedliwego / áby nie zgrzeƺył <i>ten</i> 
 
 
 
-

--- a/2023/26-eze/03.txt
+++ b/2023/26-eze/03.txt
@@ -1,0 +1,27 @@
+
+
+A mówił do mnie ; Synu cżłowiecży / nákarm brzuch twój / á wnętrznośći twoje nápełni tą kśięgą którąć dawam : y zjadłem <i>ją,</i> y byłá w uśćiech mojich ſłodka jáko miód.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ale jeſlibyś ty nápomniał ſpráwiedliwego / áby nie zgrzeƺył <i>ten</i> ſpráwiedliwy / y nie zgrzeƺyłby / zájiſte żyć będźie / bo nápomnienie przyjął : á ty duƺę ſwoję wybáwiƺ.
+
+
+
+
+
+

--- a/2023/26-eze/03.txt
+++ b/2023/26-eze/03.txt
@@ -1,6 +1,6 @@
-
-
-A mówił do mnie ; Synu cżłowiecży / nákarm brzuch twój / á wnętrznośći twoje nápełni tą kśięgą którąć dawam : y zjadłem <i>ją,</i> y byłá w uśćiech mojich ſłodka jáko miód.
+Y rzekł do mnie : Synu cżłowiecży / Co przed tobą jeſt / zjedz : zjedz ten zwój / á idź / y mów do domu Izráelſkiego.
+Otworzyłem tedy uſtá ſwe / y dał mi zjeść on zwój :
+A mówił do mnie ; Synu cżłowiecży / nákarm brzuch twój / á wnętrznośći twoje nápełni tym zwojem któryć dawam : y zjadłem <i>go,</i> y był w uśćiech mojich ſłodki jáko miód.
 
 
 
@@ -19,6 +19,7 @@ A mówił do mnie ; Synu cżłowiecży / nákarm brzuch twój / á wnętrzność
 
 
 Ale jeſlibyś ty nápomniał ſpráwiedliwego / áby nie zgrzeƺył <i>ten</i> ſpráwiedliwy / y nie zgrzeƺyłby / zájiſte żyć będźie / bo nápomnienie przyjął : á ty duƺę ſwoję wybáwiƺ.
+
 
 
 


### PR DESCRIPTION
w.1-3. l.mn. księgi -> l.poj. zwój; (TM + KJV)
TM: słowo "מגלה" (zwój) występuje w liczbie pojedynczej.
Forma mnoga brzmiałaby "מגלות", której tu brak.
słowo "מַגֵּלָה" oznacza zwinięty pergamin lub papirus, czyli fizyczny zwój tekstu, nie, bardziej abstrakcyjnie, „księgę”; por. KJV ("roll")
! warto sprawdzić inne wystąpienia w biblii tego słowa - możliwe że BG ogólnie przyjmuje pisownię tego wyrazu jako "księga"/"księgi" zamiast "zwój" - wówczas zmiana wymagana jest także w takich miejscach jeśli chcemy mieć jednolicie tłumaczone.

w.21. grzeszyć -> zgrzeszyć; x2 (TM)
słowo "חֲטֹא" jest bezokolicznikiem oznaczającym "aby nie popełnił grzechu" (czynność jednorazową), więc poprawnie tłumaczy się jako "aby nie zgrzeszył", zamiast "aby nie grzeszył"; tak samo dla drugiego wystąpienia tego słowa w zdaniu. Forma ciągła, tj. że "grzeszy" to "יֶחֱטָא".