### PR TITLE
1 Moj.23,10.

### DIFF
--- a/2023/01-gen/23.txt
+++ b/2023/01-gen/23.txt
@@ -1,0 +1,20 @@
+
+
+
+
+
+
+
+
+
+( A Efron śiedźiał w pośrzodku Synów Hetowych ) Tedy odpowiedźiał Efron Hetejcżyk Abráhámowi / w przytomnośći Synów Hetowych przed wƺyſtkimi / którzy wchodźili w bramę miáſtá jego / mówiąc :
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
chodźili -> wchodźili (TM + KJV)
słowo "בָּאֵי" oznacza wchodzić, przychodzić, wejść; nie "chodzić"; to samo słowo występuje także w wersecie 18.