### PR TITLE
Mat.15,24.

### DIFF
--- a/2023/40-mat/15.txt
+++ b/2023/40-mat/15.txt
@@ -21,7 +21,7 @@
 
 
 
-A on odpowiádájąc / rzekł ; Nie jeſtem poſłány tylko do owiec zágubionych z domu Izráelſkiego.
+A on odpowiádájąc / rzekł ; Nie jeſtem poſłány, tylko do owiec zágubionych z domu Izráelſkiego.
 
 
 

--- a/2023/40-mat/15.txt
+++ b/2023/40-mat/15.txt
@@ -21,7 +21,8 @@
 
 
 
-A on odpowiadając rzekł: Nie jestem posłany, tylko do owiec, które zginęły z domu Izraelskiego.
+A on odpowiádájąc / rzekł ; Nie jeſtem poſłány tylko do owiec zágubionych z domu Izráelſkiego.
+
 
 
 


### PR DESCRIPTION
które zginęły -> zágubione (TR + KJV)
ἀπολωλότα = zágubione


w ogólności:
Ἰσραήλ = Izrael (nazwa własna, nie przymiotnik) - zapewne do zmiany w całym tekście biblii wydania polskiego.