### PR TITLE
Objaw.5,1-5;7-9

### DIFF
--- a/2023/66-apo/05.txt
+++ b/2023/66-apo/05.txt
@@ -1,12 +1,13 @@
 Potymem widźiał po prawey ręce śiedzącego ná ſtolicy kśięgę nápiſáną / wewnątrz y zewnątrz / zápiecżętowáną śiedmią piecżęći.
-Y widźiałem Anjołá mocnego wołájącego głoſem wielkim ; Kto jeſt godźien otworzyć tę kśięgę / y odpiecżętowáć piecżęći jej?
-A nikt nie mógł áni w niebie / áni ná źiemi / áni pod źiemią / otworzyć onej Kśięgi / áni wejrzeć w nię.
+Y widźiałem Anjołá mocnego wołájącego głoſem wielkim ; Kto jeſt godźien otworzyć tę kśięgę / y odpiecżętowáć piecżęći jey?
+A nikt nie mógł áni w niebie / áni ná źiemi / áni pod źiemią / otworzyć oney Kśięgi / áni wejrzeć w nię.
 Y płákałem bárzo yż nikt nie był ználeźiony godny / áby otworzył y cżytał kśięgę / y wejrzał w nię.
-Tedy mi jeden z onych ſtárców rzekł ; Nie płácż. Oto zwyćiężył Lew / który jeſt z pokolenia Judowego / korzeń Dawidów ; áby otworzył Kśięgę / y odpiecżętował śiedm piecżęći jej.
+Tedy mi jeden z onych ſtárców rzekł ; Nie płácż. Oto zwyćiężył Lew / który jeſt z pokolenia Judowego / korzeń Dawidów ; áby otworzył Kśięgę / y odpiecżętował śiedm piecżęći jey.
 
 Ten przyƺedł ; y wźiął onę kśięgę z práwey ręki śiedzącego ná ſtolicy.
 A gdy wźiął onę kśięgę / <i>záraz</i> ono cżworo zwierząt / y oni dwádźieśćiá y cżterej ſtárcy / upádli przed Báránkiem / májąc káżdy z nich cytry y cżáƺe złote / pełne wonnych rzecży : które ſą modlitwy świętych.
-Y śpiewáli nową Pieśń / mówiąc ; Godźieneś jeſt wźiąć kśięgę / y otworzyć piecżęći jej ; żeś był zábity / y odkupiłeś nas Bogu przez krew ſwoję / ze wƺelkiego pokolenia / y języká / y ludu / y narodu :
+Y śpiewáli nową Pieśń / mówiąc ; Godźieneś jeſt wźiąć kśięgę / y otworzyć piecżęći jey ; żeś był zábity / y odkupiłeś nas Bogu przez krew ſwoję / ze wƺelkiego pokolenia / y języká / y ludu / y narodu :
+
 
 
 

--- a/2023/66-apo/05.txt
+++ b/2023/66-apo/05.txt
@@ -1,0 +1,14 @@
+Potymem widźiał po prawey ręce śiedzącego ná ſtolicy kśięgę nápiſáną / wewnątrz y zewnątrz / zápiecżętowáną śiedmią piecżęći.
+Y widźiałem Anjołá mocnego wołájącego głoſem wielkim ; Kto jeſt godźien otworzyć tę kśięgę / y odpiecżętowáć piecżęći jej?
+A nikt nie mógł áni w niebie / áni ná źiemi / áni pod źiemią / otworzyć onej Kśięgi / áni wejrzeć w nię.
+Y płákałem bárzo yż nikt nie był ználeźiony godny / áby otworzył y cżytał kśięgę / y wejrzał w nię.
+Tedy mi jeden z onych ſtárców rzekł ; Nie płácż. Oto zwyćiężył Lew / który jeſt z pokolenia Judowego / korzeń Dawidów ; áby otworzył Kśięgę / y odpiecżętował śiedm piecżęći jej.
+
+Ten przyƺedł ; y wźiął onę kśięgę z práwey ręki śiedzącego ná ſtolicy.
+A gdy wźiął onę kśięgę / <i>záraz</i> ono cżworo zwierząt / y oni dwádźieśćiá y cżterej ſtárcy / upádli przed Báránkiem / májąc káżdy z nich cytry y cżáƺe złote / pełne wonnych rzecży : które ſą modlitwy świętych.
+Y śpiewáli nową Pieśń / mówiąc ; Godźieneś jeſt wźiąć kśięgę / y otworzyć piecżęći jej ; żeś był zábity / y odkupiłeś nas Bogu przez krew ſwoję / ze wƺelkiego pokolenia / y języká / y ludu / y narodu :
+
+
+
+
+


### PR DESCRIPTION
księgi -> księga (TR + KJV)
βιβλιον - księga; liczba pojedyncza
w.3-4. ogólna zasada pisowni XVII wiecznej "w nię" zamiast "w nią" (1879 ma niejednolitą pisownię, ale 1632 ma zawsze "w nię"); współczesna pisownia: "w nią"