### PR TITLE
Dzie.1,1;20.

### DIFF
--- a/2023/44-act/01.txt
+++ b/2023/44-act/01.txt
@@ -1,0 +1,26 @@
+Pierwƺą wprawdźie Kśięgę nápiſałem / <i>ô</i> Teofile! o wƺyſtkim co pocżął JEzus y cżynić y ucżyć :
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Abowiem nápiſano w Kśiędze Pſálmów ; Niechaj będźie mieƺkánie jego puſte / á niech nie będźie ktoby w nim mieƺkał / á biſkupſtwo jego niech weźmie inny.
+
+
+
+
+
+


### PR DESCRIPTION
księgi -> księgę (TR + KJV)
λόγος - słowo, dzieło, relacja, nauczanie - liczba pojedyncza
Właściwsze jest użycie "dzieło sporządziłem" por. KJV + TR; nie jest w oryginale użyte słowo księga;
Greckie λόγος oznacza dzieło literackie / kompozycję, nie fizyczną księgę.

w.20:
βιβλω - księdze; liczba pojedyncza